### PR TITLE
Fix API response format mismatch between iOS and backend

### DIFF
--- a/backend/src/handlers/api_handler.py
+++ b/backend/src/handlers/api_handler.py
@@ -83,7 +83,7 @@ async def health_check():
 # MARK: - Resort Endpoints
 
 
-@app.get("/api/v1/resorts", response_model=list[Resort])
+@app.get("/api/v1/resorts")
 async def get_resorts(
     country: str | None = Query(None, description="Filter by country code (CA, US)"),
 ):
@@ -94,7 +94,7 @@ async def get_resorts(
         if country:
             resorts = [r for r in resorts if r.country.upper() == country.upper()]
 
-        return resorts
+        return {"resorts": resorts}
 
     except Exception as e:
         raise HTTPException(

--- a/ios/SnowTracker/SnowTracker/Sources/Services/APIClient.swift
+++ b/ios/SnowTracker/SnowTracker/Sources/Services/APIClient.swift
@@ -33,11 +33,11 @@ class APIClient {
         return try await withCheckedThrowingContinuation { continuation in
             session.request(url)
                 .validate()
-                .responseDecodable(of: [Resort].self) { response in
+                .responseDecodable(of: ResortsResponse.self) { response in
                     switch response.result {
-                    case .success(let resorts):
-                        print("Successfully decoded \(resorts.count) resorts from API")
-                        continuation.resume(returning: resorts)
+                    case .success(let resortsResponse):
+                        print("Successfully decoded \(resortsResponse.resorts.count) resorts from API")
+                        continuation.resume(returning: resortsResponse.resorts)
                     case .failure(let error):
                         print("API Error decoding resorts: \(error)")
                         continuation.resume(throwing: self.mapError(error))
@@ -71,11 +71,11 @@ class APIClient {
         return try await withCheckedThrowingContinuation { continuation in
             session.request(url)
                 .validate()
-                .responseDecodable(of: [WeatherCondition].self) { response in
+                .responseDecodable(of: ConditionsResponse.self) { response in
                     switch response.result {
-                    case .success(let conditions):
-                        print("Successfully decoded \(conditions.count) conditions for \(resortId)")
-                        continuation.resume(returning: conditions)
+                    case .success(let conditionsResponse):
+                        print("Successfully decoded \(conditionsResponse.conditions.count) conditions for \(resortId)")
+                        continuation.resume(returning: conditionsResponse.conditions)
                     case .failure(let error):
                         print("API Error decoding conditions for \(resortId): \(error)")
                         continuation.resume(throwing: self.mapError(error))
@@ -219,10 +219,12 @@ struct ResortsResponse: Codable {
 struct ConditionsResponse: Codable {
     let conditions: [WeatherCondition]
     let lastUpdated: String?
+    let resortId: String?
 
     private enum CodingKeys: String, CodingKey {
         case conditions
         case lastUpdated = "last_updated"
+        case resortId = "resort_id"
     }
 }
 


### PR DESCRIPTION
## Summary
- Update iOS APIClient to use wrapped response types (`ResortsResponse`, `ConditionsResponse`) matching the backend API format
- Update backend `get_resorts` endpoint to return wrapped `{"resorts": [...]}` format
- Fixes "No data" issue in iOS app caused by JSON decoding mismatch

## Test plan
- [ ] Run backend tests to verify API response format
- [ ] Run iOS tests to verify decoding works
- [ ] Build and launch iOS app on simulator to verify resort data loads

🤖 Generated with [Claude Code](https://claude.com/claude-code)