### PR TITLE
Fix Lambda timeout by reducing Open-Meteo API timeouts

### DIFF
--- a/backend/src/services/openmeteo_service.py
+++ b/backend/src/services/openmeteo_service.py
@@ -47,7 +47,7 @@ class OpenMeteoService:
                 "timezone": "auto",
             }
 
-            response = requests.get(self.base_url, params=params, timeout=30)
+            response = requests.get(self.base_url, params=params, timeout=10)
             response.raise_for_status()
 
             data = response.json()
@@ -67,8 +67,9 @@ class OpenMeteoService:
             weather_code = current.get("weather_code", 0)
             weather_description = self._weather_code_to_description(weather_code)
 
-            # Fetch ERA5 historical data for actual snow depth
-            era5_snow_depth = self._get_era5_snow_depth(latitude, longitude)
+            # Skip ERA5 for now to reduce Lambda execution time
+            # TODO: Add ERA5 snow depth fetching as a separate background job
+            era5_snow_depth = None
 
             weather_data = {
                 "current_temp_celsius": current.get("temperature_2m", 0.0),


### PR DESCRIPTION
## Summary
Fix weather processor Lambda timeout issue caused by too many sequential API calls.

## Changes
- Reduce forecast API timeout from 30s to 10s
- Skip ERA5 historical API calls for now (can add back as background job)
- Reduces total API calls from 84 to 42 for 14 resorts

## Root Cause
The Open-Meteo implementation was making 2 API calls per elevation point:
1. Forecast API call
2. ERA5 historical API call

With 14 resorts × 3 elevations = 42 points, this resulted in 84 total API calls
causing the Lambda to timeout.

## Test plan
- [ ] Deploy to staging and verify weather processor completes
- [ ] Verify API returns weather data for all resorts

🤖 Generated with [Claude Code](https://claude.com/claude-code)