### PR TITLE
Add CloudWatch metrics and Grafana dashboards

### DIFF
--- a/infrastructure/grafana-dashboards/README.md
+++ b/infrastructure/grafana-dashboards/README.md
@@ -1,0 +1,66 @@
+# Grafana Dashboards for Snow Tracker
+
+These dashboard JSON files can be imported into Amazon Managed Grafana to monitor the Snow Tracker application.
+
+## Dashboards
+
+### 1. Scraping Monitor (`scraping-monitor.json`)
+Monitors the weather data scraping process:
+- **Scraper Success Rate** - Percentage of successful scrapes
+- **Resorts Processed** - Number of resorts processed per hour
+- **Processing Errors** - Error count
+- **Processing Duration** - How long each scrape run takes
+- **Conditions Saved Over Time** - Weather conditions written to DynamoDB
+- **Scraper Hits vs Misses** - OnTheSnow scraper success/failure
+- **Lambda Invocations** - Weather processor Lambda execution stats
+
+### 2. API Performance (`api-performance.json`)
+Monitors API Gateway and Lambda performance:
+- **Request Count** - API requests per 5 minutes
+- **Average Latency** - Response time gauge
+- **4XX/5XX Errors** - Client and server error counts
+- **Latency Over Time** - Average and p95 latency
+- **Lambda Duration** - API handler Lambda execution time
+
+### 3. DynamoDB Metrics (`dynamodb-metrics.json`)
+Monitors database performance:
+- **Read/Write Capacity** - Consumed capacity units
+- **Throttled Requests** - Requests that hit capacity limits
+- **Request Latency** - DynamoDB operation latency
+- **Item Count & Table Size** - Storage metrics
+
+## How to Import
+
+1. Open your Grafana workspace: https://g-XXXXX.grafana-workspace.us-west-2.amazonaws.com
+2. Go to **Dashboards** → **Import**
+3. Click **Upload JSON file** and select the dashboard file
+4. Select your **CloudWatch** data source
+5. Click **Import**
+
+## Prerequisites
+
+### CloudWatch Data Source
+1. In Grafana, go to **Configuration** → **Data Sources**
+2. Add **Amazon CloudWatch**
+3. Configure with your AWS region (us-west-2)
+4. Authentication should be automatic via IAM role
+
+### Custom Metrics
+The scraping dashboard requires custom CloudWatch metrics published by the weather processor Lambda. These metrics are in the `SnowTracker/Scraping` namespace:
+- `ResortsProcessed`
+- `ElevationPointsProcessed`
+- `ConditionsSaved`
+- `ScraperHits`
+- `ScraperMisses`
+- `ProcessingErrors`
+- `ProcessingDuration`
+- `ScraperSuccessRate`
+
+## Environment Configuration
+
+The dashboards are configured for `staging` environment. To monitor other environments:
+1. After importing, edit the dashboard
+2. Find dimension values like `snow-tracker-api-staging`
+3. Change to `snow-tracker-api-prod` or `snow-tracker-api-dev`
+
+Or create dashboard variables for environment switching.

--- a/infrastructure/grafana-dashboards/api-performance.json
+++ b/infrastructure/grafana-dashboards/api-performance.json
@@ -1,0 +1,265 @@
+{
+  "dashboard": {
+    "id": null,
+    "uid": "snow-api-performance",
+    "title": "Snow Tracker - API Performance",
+    "tags": ["snow-tracker", "api", "performance"],
+    "timezone": "browser",
+    "refresh": "1m",
+    "schemaVersion": 38,
+    "panels": [
+      {
+        "id": 1,
+        "title": "API Requests (5m)",
+        "type": "stat",
+        "gridPos": { "h": 6, "w": 6, "x": 0, "y": 0 },
+        "targets": [
+          {
+            "refId": "A",
+            "namespace": "AWS/ApiGateway",
+            "metricName": "Count",
+            "dimensions": { "ApiName": "snow-tracker-api-staging" },
+            "statistic": "Sum",
+            "period": "300"
+          }
+        ],
+        "fieldConfig": {
+          "defaults": {
+            "color": { "mode": "thresholds" },
+            "thresholds": {
+              "steps": [
+                { "color": "blue", "value": null }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "id": 2,
+        "title": "Average Latency",
+        "type": "gauge",
+        "gridPos": { "h": 6, "w": 6, "x": 6, "y": 0 },
+        "targets": [
+          {
+            "refId": "A",
+            "namespace": "AWS/ApiGateway",
+            "metricName": "Latency",
+            "dimensions": { "ApiName": "snow-tracker-api-staging" },
+            "statistic": "Average",
+            "period": "300"
+          }
+        ],
+        "fieldConfig": {
+          "defaults": {
+            "unit": "ms",
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                { "color": "green", "value": null },
+                { "color": "yellow", "value": 500 },
+                { "color": "orange", "value": 1000 },
+                { "color": "red", "value": 2000 }
+              ]
+            },
+            "min": 0,
+            "max": 3000
+          }
+        }
+      },
+      {
+        "id": 3,
+        "title": "4XX Errors",
+        "type": "stat",
+        "gridPos": { "h": 6, "w": 6, "x": 12, "y": 0 },
+        "targets": [
+          {
+            "refId": "A",
+            "namespace": "AWS/ApiGateway",
+            "metricName": "4XXError",
+            "dimensions": { "ApiName": "snow-tracker-api-staging" },
+            "statistic": "Sum",
+            "period": "300"
+          }
+        ],
+        "fieldConfig": {
+          "defaults": {
+            "color": { "mode": "thresholds" },
+            "thresholds": {
+              "steps": [
+                { "color": "green", "value": null },
+                { "color": "yellow", "value": 1 },
+                { "color": "orange", "value": 10 }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "id": 4,
+        "title": "5XX Errors",
+        "type": "stat",
+        "gridPos": { "h": 6, "w": 6, "x": 18, "y": 0 },
+        "targets": [
+          {
+            "refId": "A",
+            "namespace": "AWS/ApiGateway",
+            "metricName": "5XXError",
+            "dimensions": { "ApiName": "snow-tracker-api-staging" },
+            "statistic": "Sum",
+            "period": "300"
+          }
+        ],
+        "fieldConfig": {
+          "defaults": {
+            "color": { "mode": "thresholds" },
+            "thresholds": {
+              "steps": [
+                { "color": "green", "value": null },
+                { "color": "red", "value": 1 }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "id": 5,
+        "title": "Request Count Over Time",
+        "type": "timeseries",
+        "gridPos": { "h": 8, "w": 12, "x": 0, "y": 6 },
+        "targets": [
+          {
+            "refId": "A",
+            "namespace": "AWS/ApiGateway",
+            "metricName": "Count",
+            "dimensions": { "ApiName": "snow-tracker-api-staging" },
+            "statistic": "Sum",
+            "period": "300"
+          }
+        ],
+        "fieldConfig": {
+          "defaults": {
+            "custom": {
+              "drawStyle": "bars",
+              "fillOpacity": 80
+            },
+            "color": { "fixedColor": "blue", "mode": "fixed" }
+          }
+        }
+      },
+      {
+        "id": 6,
+        "title": "Latency Over Time",
+        "type": "timeseries",
+        "gridPos": { "h": 8, "w": 12, "x": 12, "y": 6 },
+        "targets": [
+          {
+            "refId": "A",
+            "namespace": "AWS/ApiGateway",
+            "metricName": "Latency",
+            "dimensions": { "ApiName": "snow-tracker-api-staging" },
+            "statistic": "Average",
+            "period": "300",
+            "alias": "Average"
+          },
+          {
+            "refId": "B",
+            "namespace": "AWS/ApiGateway",
+            "metricName": "Latency",
+            "dimensions": { "ApiName": "snow-tracker-api-staging" },
+            "statistic": "p95",
+            "period": "300",
+            "alias": "p95"
+          }
+        ],
+        "fieldConfig": {
+          "defaults": {
+            "unit": "ms",
+            "custom": {
+              "drawStyle": "line",
+              "lineWidth": 2
+            }
+          }
+        }
+      },
+      {
+        "id": 7,
+        "title": "Error Rate Over Time",
+        "type": "timeseries",
+        "gridPos": { "h": 8, "w": 12, "x": 0, "y": 14 },
+        "targets": [
+          {
+            "refId": "A",
+            "namespace": "AWS/ApiGateway",
+            "metricName": "4XXError",
+            "dimensions": { "ApiName": "snow-tracker-api-staging" },
+            "statistic": "Sum",
+            "period": "300",
+            "alias": "4XX Errors"
+          },
+          {
+            "refId": "B",
+            "namespace": "AWS/ApiGateway",
+            "metricName": "5XXError",
+            "dimensions": { "ApiName": "snow-tracker-api-staging" },
+            "statistic": "Sum",
+            "period": "300",
+            "alias": "5XX Errors"
+          }
+        ],
+        "fieldConfig": {
+          "defaults": {
+            "custom": {
+              "drawStyle": "line",
+              "lineWidth": 2,
+              "fillOpacity": 20
+            }
+          },
+          "overrides": [
+            { "matcher": { "id": "byName", "options": "4XX Errors" }, "properties": [{ "id": "color", "value": { "fixedColor": "orange", "mode": "fixed" } }] },
+            { "matcher": { "id": "byName", "options": "5XX Errors" }, "properties": [{ "id": "color", "value": { "fixedColor": "red", "mode": "fixed" } }] }
+          ]
+        }
+      },
+      {
+        "id": 8,
+        "title": "Lambda Duration",
+        "type": "timeseries",
+        "gridPos": { "h": 8, "w": 12, "x": 12, "y": 14 },
+        "targets": [
+          {
+            "refId": "A",
+            "namespace": "AWS/Lambda",
+            "metricName": "Duration",
+            "dimensions": { "FunctionName": "snow-tracker-api-handler-staging" },
+            "statistic": "Average",
+            "period": "300",
+            "alias": "Avg Duration"
+          },
+          {
+            "refId": "B",
+            "namespace": "AWS/Lambda",
+            "metricName": "Duration",
+            "dimensions": { "FunctionName": "snow-tracker-api-handler-staging" },
+            "statistic": "Maximum",
+            "period": "300",
+            "alias": "Max Duration"
+          }
+        ],
+        "fieldConfig": {
+          "defaults": {
+            "unit": "ms",
+            "custom": {
+              "drawStyle": "line",
+              "lineWidth": 2
+            }
+          }
+        }
+      }
+    ],
+    "time": {
+      "from": "now-6h",
+      "to": "now"
+    }
+  },
+  "overwrite": true
+}

--- a/infrastructure/grafana-dashboards/dynamodb-metrics.json
+++ b/infrastructure/grafana-dashboards/dynamodb-metrics.json
@@ -1,0 +1,216 @@
+{
+  "dashboard": {
+    "id": null,
+    "uid": "snow-dynamodb-metrics",
+    "title": "Snow Tracker - DynamoDB Metrics",
+    "tags": ["snow-tracker", "dynamodb", "database"],
+    "timezone": "browser",
+    "refresh": "5m",
+    "schemaVersion": 38,
+    "panels": [
+      {
+        "id": 1,
+        "title": "Resorts Table - Read/Write Capacity",
+        "type": "timeseries",
+        "gridPos": { "h": 8, "w": 12, "x": 0, "y": 0 },
+        "targets": [
+          {
+            "refId": "A",
+            "namespace": "AWS/DynamoDB",
+            "metricName": "ConsumedReadCapacityUnits",
+            "dimensions": { "TableName": "snow-tracker-resorts-staging" },
+            "statistic": "Sum",
+            "period": "300",
+            "alias": "Read"
+          },
+          {
+            "refId": "B",
+            "namespace": "AWS/DynamoDB",
+            "metricName": "ConsumedWriteCapacityUnits",
+            "dimensions": { "TableName": "snow-tracker-resorts-staging" },
+            "statistic": "Sum",
+            "period": "300",
+            "alias": "Write"
+          }
+        ],
+        "fieldConfig": {
+          "defaults": {
+            "custom": {
+              "drawStyle": "line",
+              "lineWidth": 2,
+              "fillOpacity": 20
+            }
+          },
+          "overrides": [
+            { "matcher": { "id": "byName", "options": "Read" }, "properties": [{ "id": "color", "value": { "fixedColor": "blue", "mode": "fixed" } }] },
+            { "matcher": { "id": "byName", "options": "Write" }, "properties": [{ "id": "color", "value": { "fixedColor": "green", "mode": "fixed" } }] }
+          ]
+        }
+      },
+      {
+        "id": 2,
+        "title": "Weather Conditions Table - Read/Write",
+        "type": "timeseries",
+        "gridPos": { "h": 8, "w": 12, "x": 12, "y": 0 },
+        "targets": [
+          {
+            "refId": "A",
+            "namespace": "AWS/DynamoDB",
+            "metricName": "ConsumedReadCapacityUnits",
+            "dimensions": { "TableName": "snow-tracker-weather-conditions-staging" },
+            "statistic": "Sum",
+            "period": "300",
+            "alias": "Read"
+          },
+          {
+            "refId": "B",
+            "namespace": "AWS/DynamoDB",
+            "metricName": "ConsumedWriteCapacityUnits",
+            "dimensions": { "TableName": "snow-tracker-weather-conditions-staging" },
+            "statistic": "Sum",
+            "period": "300",
+            "alias": "Write"
+          }
+        ],
+        "fieldConfig": {
+          "defaults": {
+            "custom": {
+              "drawStyle": "line",
+              "lineWidth": 2,
+              "fillOpacity": 20
+            }
+          },
+          "overrides": [
+            { "matcher": { "id": "byName", "options": "Read" }, "properties": [{ "id": "color", "value": { "fixedColor": "blue", "mode": "fixed" } }] },
+            { "matcher": { "id": "byName", "options": "Write" }, "properties": [{ "id": "color", "value": { "fixedColor": "green", "mode": "fixed" } }] }
+          ]
+        }
+      },
+      {
+        "id": 3,
+        "title": "Throttled Requests",
+        "type": "timeseries",
+        "gridPos": { "h": 8, "w": 12, "x": 0, "y": 8 },
+        "targets": [
+          {
+            "refId": "A",
+            "namespace": "AWS/DynamoDB",
+            "metricName": "ThrottledRequests",
+            "dimensions": { "TableName": "snow-tracker-resorts-staging" },
+            "statistic": "Sum",
+            "period": "300",
+            "alias": "Resorts"
+          },
+          {
+            "refId": "B",
+            "namespace": "AWS/DynamoDB",
+            "metricName": "ThrottledRequests",
+            "dimensions": { "TableName": "snow-tracker-weather-conditions-staging" },
+            "statistic": "Sum",
+            "period": "300",
+            "alias": "Weather"
+          }
+        ],
+        "fieldConfig": {
+          "defaults": {
+            "custom": {
+              "drawStyle": "line",
+              "lineWidth": 2,
+              "fillOpacity": 20
+            },
+            "color": { "fixedColor": "red", "mode": "fixed" }
+          }
+        }
+      },
+      {
+        "id": 4,
+        "title": "Successful Requests Latency",
+        "type": "timeseries",
+        "gridPos": { "h": 8, "w": 12, "x": 12, "y": 8 },
+        "targets": [
+          {
+            "refId": "A",
+            "namespace": "AWS/DynamoDB",
+            "metricName": "SuccessfulRequestLatency",
+            "dimensions": { "TableName": "snow-tracker-resorts-staging", "Operation": "GetItem" },
+            "statistic": "Average",
+            "period": "300",
+            "alias": "Resorts GetItem"
+          },
+          {
+            "refId": "B",
+            "namespace": "AWS/DynamoDB",
+            "metricName": "SuccessfulRequestLatency",
+            "dimensions": { "TableName": "snow-tracker-weather-conditions-staging", "Operation": "Query" },
+            "statistic": "Average",
+            "period": "300",
+            "alias": "Weather Query"
+          }
+        ],
+        "fieldConfig": {
+          "defaults": {
+            "unit": "ms",
+            "custom": {
+              "drawStyle": "line",
+              "lineWidth": 2
+            }
+          }
+        }
+      },
+      {
+        "id": 5,
+        "title": "Item Count (Weather Conditions)",
+        "type": "stat",
+        "gridPos": { "h": 4, "w": 6, "x": 0, "y": 16 },
+        "targets": [
+          {
+            "refId": "A",
+            "namespace": "AWS/DynamoDB",
+            "metricName": "ItemCount",
+            "dimensions": { "TableName": "snow-tracker-weather-conditions-staging" },
+            "statistic": "Average",
+            "period": "86400"
+          }
+        ],
+        "fieldConfig": {
+          "defaults": {
+            "color": { "mode": "thresholds" },
+            "thresholds": {
+              "steps": [{ "color": "blue", "value": null }]
+            }
+          }
+        }
+      },
+      {
+        "id": 6,
+        "title": "Table Size (Weather Conditions)",
+        "type": "stat",
+        "gridPos": { "h": 4, "w": 6, "x": 6, "y": 16 },
+        "targets": [
+          {
+            "refId": "A",
+            "namespace": "AWS/DynamoDB",
+            "metricName": "TableSize",
+            "dimensions": { "TableName": "snow-tracker-weather-conditions-staging" },
+            "statistic": "Average",
+            "period": "86400"
+          }
+        ],
+        "fieldConfig": {
+          "defaults": {
+            "unit": "bytes",
+            "color": { "mode": "thresholds" },
+            "thresholds": {
+              "steps": [{ "color": "blue", "value": null }]
+            }
+          }
+        }
+      }
+    ],
+    "time": {
+      "from": "now-24h",
+      "to": "now"
+    }
+  },
+  "overwrite": true
+}

--- a/infrastructure/grafana-dashboards/scraping-monitor.json
+++ b/infrastructure/grafana-dashboards/scraping-monitor.json
@@ -1,0 +1,286 @@
+{
+  "dashboard": {
+    "id": null,
+    "uid": "snow-scraping-monitor",
+    "title": "Snow Tracker - Scraping Monitor",
+    "tags": ["snow-tracker", "scraping", "weather"],
+    "timezone": "browser",
+    "refresh": "5m",
+    "schemaVersion": 38,
+    "panels": [
+      {
+        "id": 1,
+        "title": "Scraper Success Rate",
+        "type": "gauge",
+        "gridPos": { "h": 8, "w": 6, "x": 0, "y": 0 },
+        "targets": [
+          {
+            "refId": "A",
+            "namespace": "SnowTracker/Scraping",
+            "metricName": "ScraperSuccessRate",
+            "dimensions": { "Environment": ["staging", "prod"] },
+            "statistic": "Average",
+            "period": "300"
+          }
+        ],
+        "fieldConfig": {
+          "defaults": {
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                { "color": "red", "value": null },
+                { "color": "orange", "value": 50 },
+                { "color": "yellow", "value": 75 },
+                { "color": "green", "value": 90 }
+              ]
+            },
+            "unit": "percent",
+            "min": 0,
+            "max": 100
+          }
+        }
+      },
+      {
+        "id": 2,
+        "title": "Resorts Processed",
+        "type": "stat",
+        "gridPos": { "h": 4, "w": 6, "x": 6, "y": 0 },
+        "targets": [
+          {
+            "refId": "A",
+            "namespace": "SnowTracker/Scraping",
+            "metricName": "ResortsProcessed",
+            "dimensions": { "Environment": ["staging", "prod"] },
+            "statistic": "Sum",
+            "period": "3600"
+          }
+        ],
+        "fieldConfig": {
+          "defaults": {
+            "color": { "mode": "thresholds" },
+            "thresholds": {
+              "steps": [
+                { "color": "red", "value": null },
+                { "color": "green", "value": 1 }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "id": 3,
+        "title": "Processing Errors",
+        "type": "stat",
+        "gridPos": { "h": 4, "w": 6, "x": 12, "y": 0 },
+        "targets": [
+          {
+            "refId": "A",
+            "namespace": "SnowTracker/Scraping",
+            "metricName": "ProcessingErrors",
+            "dimensions": { "Environment": ["staging", "prod"] },
+            "statistic": "Sum",
+            "period": "3600"
+          }
+        ],
+        "fieldConfig": {
+          "defaults": {
+            "color": { "mode": "thresholds" },
+            "thresholds": {
+              "steps": [
+                { "color": "green", "value": null },
+                { "color": "yellow", "value": 1 },
+                { "color": "red", "value": 5 }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "id": 4,
+        "title": "Processing Duration",
+        "type": "stat",
+        "gridPos": { "h": 4, "w": 6, "x": 18, "y": 0 },
+        "targets": [
+          {
+            "refId": "A",
+            "namespace": "SnowTracker/Scraping",
+            "metricName": "ProcessingDuration",
+            "dimensions": { "Environment": ["staging", "prod"] },
+            "statistic": "Average",
+            "period": "300"
+          }
+        ],
+        "fieldConfig": {
+          "defaults": {
+            "unit": "s",
+            "color": { "mode": "thresholds" },
+            "thresholds": {
+              "steps": [
+                { "color": "green", "value": null },
+                { "color": "yellow", "value": 60 },
+                { "color": "red", "value": 120 }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "id": 5,
+        "title": "Conditions Saved Over Time",
+        "type": "timeseries",
+        "gridPos": { "h": 8, "w": 12, "x": 6, "y": 4 },
+        "targets": [
+          {
+            "refId": "A",
+            "namespace": "SnowTracker/Scraping",
+            "metricName": "ConditionsSaved",
+            "dimensions": { "Environment": ["staging", "prod"] },
+            "statistic": "Sum",
+            "period": "3600"
+          }
+        ],
+        "fieldConfig": {
+          "defaults": {
+            "custom": {
+              "drawStyle": "line",
+              "lineWidth": 2,
+              "fillOpacity": 20
+            },
+            "color": { "mode": "palette-classic" }
+          }
+        }
+      },
+      {
+        "id": 6,
+        "title": "Scraper Hits vs Misses",
+        "type": "timeseries",
+        "gridPos": { "h": 8, "w": 12, "x": 0, "y": 8 },
+        "targets": [
+          {
+            "refId": "A",
+            "namespace": "SnowTracker/Scraping",
+            "metricName": "ScraperHits",
+            "dimensions": { "Environment": ["staging", "prod"] },
+            "statistic": "Sum",
+            "period": "3600",
+            "alias": "Hits"
+          },
+          {
+            "refId": "B",
+            "namespace": "SnowTracker/Scraping",
+            "metricName": "ScraperMisses",
+            "dimensions": { "Environment": ["staging", "prod"] },
+            "statistic": "Sum",
+            "period": "3600",
+            "alias": "Misses"
+          }
+        ],
+        "fieldConfig": {
+          "defaults": {
+            "custom": {
+              "drawStyle": "bars",
+              "fillOpacity": 80,
+              "stacking": { "mode": "normal" }
+            }
+          },
+          "overrides": [
+            { "matcher": { "id": "byName", "options": "Hits" }, "properties": [{ "id": "color", "value": { "fixedColor": "green", "mode": "fixed" } }] },
+            { "matcher": { "id": "byName", "options": "Misses" }, "properties": [{ "id": "color", "value": { "fixedColor": "red", "mode": "fixed" } }] }
+          ]
+        }
+      },
+      {
+        "id": 7,
+        "title": "Processing Errors Over Time",
+        "type": "timeseries",
+        "gridPos": { "h": 8, "w": 12, "x": 12, "y": 8 },
+        "targets": [
+          {
+            "refId": "A",
+            "namespace": "SnowTracker/Scraping",
+            "metricName": "ProcessingErrors",
+            "dimensions": { "Environment": ["staging", "prod"] },
+            "statistic": "Sum",
+            "period": "3600"
+          }
+        ],
+        "fieldConfig": {
+          "defaults": {
+            "custom": {
+              "drawStyle": "line",
+              "lineWidth": 2,
+              "fillOpacity": 20
+            },
+            "color": { "fixedColor": "red", "mode": "fixed" }
+          }
+        }
+      },
+      {
+        "id": 8,
+        "title": "Elevation Points Processed",
+        "type": "timeseries",
+        "gridPos": { "h": 8, "w": 12, "x": 0, "y": 16 },
+        "targets": [
+          {
+            "refId": "A",
+            "namespace": "SnowTracker/Scraping",
+            "metricName": "ElevationPointsProcessed",
+            "dimensions": { "Environment": ["staging", "prod"] },
+            "statistic": "Sum",
+            "period": "3600"
+          }
+        ],
+        "fieldConfig": {
+          "defaults": {
+            "custom": {
+              "drawStyle": "line",
+              "lineWidth": 2,
+              "fillOpacity": 20
+            },
+            "color": { "mode": "palette-classic" }
+          }
+        }
+      },
+      {
+        "id": 9,
+        "title": "Weather Processor Lambda Invocations",
+        "type": "timeseries",
+        "gridPos": { "h": 8, "w": 12, "x": 12, "y": 16 },
+        "targets": [
+          {
+            "refId": "A",
+            "namespace": "AWS/Lambda",
+            "metricName": "Invocations",
+            "dimensions": { "FunctionName": "snow-tracker-weather-processor-staging" },
+            "statistic": "Sum",
+            "period": "3600"
+          },
+          {
+            "refId": "B",
+            "namespace": "AWS/Lambda",
+            "metricName": "Errors",
+            "dimensions": { "FunctionName": "snow-tracker-weather-processor-staging" },
+            "statistic": "Sum",
+            "period": "3600"
+          }
+        ],
+        "fieldConfig": {
+          "defaults": {
+            "custom": {
+              "drawStyle": "line",
+              "lineWidth": 2
+            }
+          },
+          "overrides": [
+            { "matcher": { "id": "byFrameRefID", "options": "B" }, "properties": [{ "id": "color", "value": { "fixedColor": "red", "mode": "fixed" } }] }
+          ]
+        }
+      }
+    ],
+    "time": {
+      "from": "now-24h",
+      "to": "now"
+    }
+  },
+  "overwrite": true
+}


### PR DESCRIPTION
## Summary
- Add custom CloudWatch metrics to weather processor Lambda for scraping monitoring
- Create 3 Grafana dashboard JSON files ready to import

## Custom Metrics (SnowTracker/Scraping namespace)
- `ResortsProcessed` - Count of resorts processed per run
- `ElevationPointsProcessed` - Count of elevation points updated
- `ConditionsSaved` - Weather conditions written to DynamoDB
- `ScraperHits` / `ScraperMisses` - OnTheSnow scraper success/failure
- `ProcessingErrors` - Error count
- `ProcessingDuration` - Execution time in seconds
- `ScraperSuccessRate` - Percentage success rate

## Grafana Dashboards
1. **Scraping Monitor** - Weather data collection health
2. **API Performance** - API Gateway latency, errors, request counts
3. **DynamoDB Metrics** - Database read/write capacity, throttling

## How to Use
1. Deploy to staging to start emitting custom metrics
2. Import dashboard JSON files into Grafana
3. Configure CloudWatch data source if not already done

## Test plan
- [ ] Deploy to staging
- [ ] Verify metrics appear in CloudWatch console
- [ ] Import dashboards into Grafana
- [ ] Verify data displays correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)