### PR TITLE
Fix API offline mode and snow quality display issues

### DIFF
--- a/backend/tests/test_models.py
+++ b/backend/tests/test_models.py
@@ -200,11 +200,12 @@ class TestWeatherModels:
         assert SnowQuality.FAIR == "fair"
         assert SnowQuality.POOR == "poor"
         assert SnowQuality.BAD == "bad"
+        assert SnowQuality.HORRIBLE == "horrible"
         assert SnowQuality.UNKNOWN == "unknown"
 
-        # Test all values are present
+        # Test all values are present (excellent, good, fair, poor, bad, horrible, unknown)
         all_qualities = list(SnowQuality)
-        assert len(all_qualities) == 6
+        assert len(all_qualities) == 7
 
     def test_confidence_level_enum(self):
         """Test ConfidenceLevel enum values."""


### PR DESCRIPTION
## Summary

This PR fixes three issues reported with the iOS app:

- **"Unknown time" display**: Fixed ISO8601 timestamp parsing to handle fractional seconds (e.g., `2026-01-25T21:18:24.110234+00:00`)
- **Wrong snow quality display**: Fixed batch API fallback to use individual `/resorts/{id}/conditions` endpoints when batch endpoint fails
- **"Offline mode" indicator**: Improved caching state tracking to properly reflect whether data is fresh or from cache

## Root Cause Analysis

1. The batch endpoint (`/api/v1/conditions/batch`) is not registered in API Gateway, returning "Missing Authentication Token" errors
2. The iOS `ISO8601DateFormatter` defaults don't parse fractional seconds
3. The `isUsingCachedData` flag wasn't being reset properly in all scenarios

## Changes

### iOS (`WeatherCondition.swift`)
- Added `parsedTimestamp` computed property with fractional seconds support
- Refactored `formattedTimestamp`, `isRecent`, and `ageInHours` to use shared parsing

### iOS (`Managers.swift`)
- Updated `fetchAllConditions()` to fall back to individual API calls when batch fails
- Fixed `isUsingCachedData` flag logic to properly track cache state

### Backend Tests
- Fixed `test_snow_quality_enum` to expect 7 values (added HORRIBLE)

## Test plan
- [x] Backend model tests pass locally
- [ ] iOS unit tests pass in CI
- [ ] iOS UI tests pass in CI
- [ ] Manual testing: Verify "2 min ago" shows instead of "Unknown time"
- [ ] Manual testing: Verify "Poor" quality shows for Big White (API returns poor)
- [ ] Manual testing: Verify offline indicator only shows when using cached data