### PR TITLE
Fix iOS recommendations decoding and Apple Sign In email

### DIFF
--- a/ios/SnowTracker/SnowTracker/Sources/Services/APIClient.swift
+++ b/ios/SnowTracker/SnowTracker/Sources/Services/APIClient.swift
@@ -887,15 +887,15 @@ struct FeedbackSubmission: Codable {
 
 struct RecommendationsResponse: Codable {
     let recommendations: [ResortRecommendation]
-    let searchLocation: SearchLocation?
+    let searchCenter: SearchLocation?
     let searchRadiusKm: Double?
-    let timestamp: String
+    let generatedAt: String
 
     private enum CodingKeys: String, CodingKey {
         case recommendations
-        case searchLocation = "search_location"
+        case searchCenter = "search_center"
         case searchRadiusKm = "search_radius_km"
-        case timestamp
+        case generatedAt = "generated_at"
     }
 }
 


### PR DESCRIPTION
## Summary
- Fix RecommendationsResponse model field names to match backend API response
- Fix Apple Sign In to call backend auth endpoint and retrieve email (including private relay addresses)

## Changes
1. **APIClient.swift**: Update `RecommendationsResponse` model:
   - `searchLocation` → `searchCenter` (CodingKey: `search_center`)
   - `timestamp` → `generatedAt` (CodingKey: `generated_at`)

2. **AuthenticationService.swift**: Fix Apple Sign In flow:
   - Actually call backend `/api/v1/auth/apple` endpoint
   - Retrieve and store email from backend (includes Apple's private relay emails)
   - Store access and refresh tokens from backend
   - Fall back to local auth if backend call fails

## Test plan
- [ ] Test Best Snow tab loads without decoding errors
- [ ] Test pull-to-refresh on Best Snow tab works
- [ ] Test Apple Sign In shows private relay email in profile

Closes the iOS decoding errors on Best Snow tab.
Shows Apple Sign In hidden email addresses (privaterelay.appleid.com).

🤖 Generated with [Claude Code](https://claude.com/claude-code)