### PR TITLE
Add missing env vars to API handler Lambda

### DIFF
--- a/infrastructure/__main__.py
+++ b/infrastructure/__main__.py
@@ -649,7 +649,10 @@ def get_conditions(resort_id, headers):
             "ENVIRONMENT": environment,
             "RESORTS_TABLE": f"{app_name}-resorts-{environment}",
             "WEATHER_CONDITIONS_TABLE": f"{app_name}-weather-conditions-{environment}",
+            "USER_PREFERENCES_TABLE": f"{app_name}-user-preferences-{environment}",
             "FEEDBACK_TABLE": f"{app_name}-feedback-{environment}",
+            "DEVICE_TOKENS_TABLE": f"{app_name}-device-tokens-{environment}",
+            "RESORT_EVENTS_TABLE": f"{app_name}-resort-events-{environment}",
             "AWS_REGION_NAME": aws_region,
         }
     ),


### PR DESCRIPTION
## Summary
Add missing environment variables to API handler Lambda for notification tables:
- DEVICE_TOKENS_TABLE
- RESORT_EVENTS_TABLE
- USER_PREFERENCES_TABLE

## Problem
The events endpoint was returning AccessDeniedException because it was defaulting to the dev table name instead of using the staging table.

## Test Plan
- [ ] GET /api/v1/resorts/{resortId}/events returns empty array
- [ ] POST /api/v1/resorts/{resortId}/events creates an event

https://claude.ai/code/session_011QvDuSnZFmdrBgkXiH5nes