### PR TITLE
Implement parallel resort scraper with orchestrator/worker pattern

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -265,6 +265,46 @@ jobs:
           echo "Notification processor Lambda updated"
         fi
 
+        # Deploy Scraper Orchestrator Lambda
+        SCRAPER_ORCHESTRATOR=$(pulumi stack output scraper_orchestrator_lambda_name 2>/dev/null || echo "")
+        if [ -n "$SCRAPER_ORCHESTRATOR" ]; then
+          echo "Deploying Scraper orchestrator Lambda: $SCRAPER_ORCHESTRATOR"
+          aws lambda update-function-code \
+            --function-name "$SCRAPER_ORCHESTRATOR" \
+            --s3-bucket "$S3_BUCKET" \
+            --s3-key "$S3_KEY" \
+            --region us-west-2
+          aws lambda wait function-updated --function-name "$SCRAPER_ORCHESTRATOR" --region us-west-2
+
+          # Update Scraper Orchestrator Lambda environment variables
+          aws lambda update-function-configuration \
+            --function-name "$SCRAPER_ORCHESTRATOR" \
+            --environment "Variables={ENVIRONMENT=${{ env.ENVIRONMENT }},RESORTS_TABLE=snow-tracker-resorts-${{ env.ENVIRONMENT }},SCRAPER_WORKER_LAMBDA=snow-tracker-scraper-worker-${{ env.ENVIRONMENT }},RESULTS_BUCKET=snow-tracker-pulumi-state-us-west-2,AWS_REGION_NAME=us-west-2}" \
+            --region us-west-2
+          aws lambda wait function-updated --function-name "$SCRAPER_ORCHESTRATOR" --region us-west-2
+          echo "Scraper orchestrator Lambda updated"
+        fi
+
+        # Deploy Scraper Worker Lambda
+        SCRAPER_WORKER=$(pulumi stack output scraper_worker_lambda_name 2>/dev/null || echo "")
+        if [ -n "$SCRAPER_WORKER" ]; then
+          echo "Deploying Scraper worker Lambda: $SCRAPER_WORKER"
+          aws lambda update-function-code \
+            --function-name "$SCRAPER_WORKER" \
+            --s3-bucket "$S3_BUCKET" \
+            --s3-key "$S3_KEY" \
+            --region us-west-2
+          aws lambda wait function-updated --function-name "$SCRAPER_WORKER" --region us-west-2
+
+          # Update Scraper Worker Lambda environment variables
+          aws lambda update-function-configuration \
+            --function-name "$SCRAPER_WORKER" \
+            --environment "Variables={ENVIRONMENT=${{ env.ENVIRONMENT }},RESORTS_TABLE=snow-tracker-resorts-${{ env.ENVIRONMENT }},RESULTS_BUCKET=snow-tracker-pulumi-state-us-west-2,AWS_REGION_NAME=us-west-2}" \
+            --region us-west-2
+          aws lambda wait function-updated --function-name "$SCRAPER_WORKER" --region us-west-2
+          echo "Scraper worker Lambda updated"
+        fi
+
         echo "Lambda deployment complete"
 
     - name: Seed resort data (dev/staging only)

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -9,6 +9,7 @@ python-jose[cryptography]>=3.3.0
 python-multipart>=0.0.6
 cachetools>=5.3.0
 beautifulsoup4>=4.12.0
+lxml>=5.0.0
 
 # Testing
 pytest>=7.4.0

--- a/backend/src/handlers/scraper_orchestrator.py
+++ b/backend/src/handlers/scraper_orchestrator.py
@@ -1,0 +1,407 @@
+"""Lambda handler for orchestrating parallel resort scraping.
+
+This orchestrator Lambda fans out to worker Lambdas, each processing
+one country in parallel for faster scraping.
+"""
+
+import json
+import logging
+import os
+from datetime import UTC, datetime
+from typing import Any
+
+import boto3
+
+# Configure logging
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
+
+# Initialize AWS clients
+lambda_client = boto3.client("lambda")
+dynamodb = boto3.resource("dynamodb")
+cloudwatch = boto3.client("cloudwatch")
+s3 = boto3.client("s3")
+
+# Environment variables
+ENVIRONMENT = os.environ.get("ENVIRONMENT", "dev")
+SCRAPER_WORKER_LAMBDA = os.environ.get(
+    "SCRAPER_WORKER_LAMBDA", f"snow-tracker-scraper-worker-{ENVIRONMENT}"
+)
+RESULTS_BUCKET = os.environ.get("RESULTS_BUCKET", "snow-tracker-pulumi-state-us-west-2")
+RESORTS_TABLE = os.environ.get("RESORTS_TABLE", "snow-tracker-resorts-dev")
+
+# Countries to scrape, grouped by priority/size
+# Group 1: Major markets (process first)
+PRIORITY_COUNTRIES = ["US", "CA", "AT", "CH", "FR", "IT", "JP"]
+# Group 2: Secondary markets
+SECONDARY_COUNTRIES = ["DE", "NO", "SE", "AU", "NZ", "CL", "AR"]
+# Group 3: Other markets
+OTHER_COUNTRIES = ["FI", "ES", "AD", "PL", "CZ", "SK", "SI", "KR", "CN"]
+
+ALL_COUNTRIES = PRIORITY_COUNTRIES + SECONDARY_COUNTRIES + OTHER_COUNTRIES
+
+
+def is_first_of_month() -> bool:
+    """Check if today is the first day of the month."""
+    return datetime.now(UTC).day == 1
+
+
+def publish_orchestrator_metrics(stats: dict[str, Any]) -> None:
+    """Publish orchestrator metrics to CloudWatch."""
+    try:
+        metrics = [
+            {
+                "MetricName": "ScraperWorkersInvoked",
+                "Value": stats.get("workers_invoked", 0),
+                "Unit": "Count",
+                "Dimensions": [{"Name": "Environment", "Value": ENVIRONMENT}],
+            },
+            {
+                "MetricName": "ScraperWorkersFailed",
+                "Value": stats.get("workers_failed", 0),
+                "Unit": "Count",
+                "Dimensions": [{"Name": "Environment", "Value": ENVIRONMENT}],
+            },
+            {
+                "MetricName": "ScraperMode",
+                "Value": 1.0 if stats.get("full_scrape") else 0.0,
+                "Unit": "None",
+                "Dimensions": [{"Name": "Environment", "Value": ENVIRONMENT}],
+            },
+            {
+                "MetricName": "ScraperOrchestrationDuration",
+                "Value": stats.get("duration_seconds", 0),
+                "Unit": "Seconds",
+                "Dimensions": [{"Name": "Environment", "Value": ENVIRONMENT}],
+            },
+        ]
+
+        cloudwatch.put_metric_data(
+            Namespace="SnowTracker/ScraperOrchestrator", MetricData=metrics
+        )
+        logger.info("Published orchestrator metrics")
+
+    except Exception as e:
+        logger.error(f"Failed to publish orchestrator metrics: {e}")
+
+
+def scraper_orchestrator_handler(event: dict[str, Any], context) -> dict[str, Any]:
+    """
+    Lambda handler for orchestrating parallel resort scraping.
+
+    Invokes worker Lambdas for each country in parallel.
+
+    Args:
+        event: Contains:
+            - full_scrape: If true, scrape all resorts (ignore existing)
+                          If false (default), only scrape new resorts
+            - countries: Optional list of specific countries to scrape
+        context: Lambda context object
+
+    Returns:
+        Dict with orchestration results
+    """
+    start_time = datetime.now(UTC)
+    job_id = start_time.strftime("%Y%m%d%H%M%S")
+
+    # Determine scrape mode
+    # Full scrape on first of month or if explicitly requested
+    full_scrape = event.get("full_scrape", False) or is_first_of_month()
+    delta_mode = not full_scrape
+
+    # Get countries to scrape
+    countries = event.get("countries", ALL_COUNTRIES)
+
+    logger.info(
+        f"Starting scraper orchestration: job_id={job_id}, "
+        f"full_scrape={full_scrape}, countries={len(countries)}"
+    )
+
+    stats = {
+        "job_id": job_id,
+        "full_scrape": full_scrape,
+        "workers_invoked": 0,
+        "workers_failed": 0,
+        "countries": [],
+        "start_time": start_time.isoformat(),
+    }
+
+    invocations = []
+
+    # Invoke worker Lambda for each country
+    for country in countries:
+        try:
+            payload = {
+                "country": country,
+                "delta_mode": delta_mode,
+                "job_id": job_id,
+            }
+
+            logger.info(f"Invoking scraper worker for {country}")
+
+            response = lambda_client.invoke(
+                FunctionName=SCRAPER_WORKER_LAMBDA,
+                InvocationType="Event",  # Async invocation
+                Payload=json.dumps(payload),
+            )
+
+            success = response.get("StatusCode") == 202
+            invocations.append(
+                {
+                    "country": country,
+                    "status_code": response.get("StatusCode"),
+                    "success": success,
+                }
+            )
+
+            if success:
+                stats["workers_invoked"] += 1
+                stats["countries"].append(country)
+            else:
+                stats["workers_failed"] += 1
+
+        except Exception as e:
+            logger.error(f"Failed to invoke worker for {country}: {e}")
+            invocations.append(
+                {
+                    "country": country,
+                    "error": str(e),
+                    "success": False,
+                }
+            )
+            stats["workers_failed"] += 1
+
+    stats["end_time"] = datetime.now(UTC).isoformat()
+    stats["duration_seconds"] = (datetime.now(UTC) - start_time).total_seconds()
+
+    # Store job metadata in S3
+    try:
+        job_metadata = {
+            "job_id": job_id,
+            "start_time": stats["start_time"],
+            "full_scrape": full_scrape,
+            "countries": countries,
+            "invocations": invocations,
+        }
+        s3.put_object(
+            Bucket=RESULTS_BUCKET,
+            Key=f"scraper-results/{job_id}/job_metadata.json",
+            Body=json.dumps(job_metadata),
+            ContentType="application/json",
+        )
+        logger.info(
+            f"Stored job metadata to s3://{RESULTS_BUCKET}/scraper-results/{job_id}/"
+        )
+    except Exception as e:
+        logger.error(f"Failed to store job metadata: {e}")
+
+    # Publish metrics
+    publish_orchestrator_metrics(stats)
+
+    logger.info(
+        f"Orchestration complete: {stats['workers_invoked']} workers invoked, "
+        f"{stats['workers_failed']} failed, duration={stats['duration_seconds']:.2f}s"
+    )
+
+    return {
+        "statusCode": 200,
+        "body": json.dumps(
+            {
+                "message": f"Dispatched {stats['workers_invoked']} scraper workers",
+                "job_id": job_id,
+                "mode": "full" if full_scrape else "delta",
+                "workers_invoked": stats["workers_invoked"],
+                "workers_failed": stats["workers_failed"],
+                "countries": stats["countries"],
+                "duration_seconds": stats["duration_seconds"],
+            }
+        ),
+    }
+
+
+def process_scraper_results_handler(event: dict[str, Any], context) -> dict[str, Any]:
+    """
+    Lambda handler for processing scraper results and populating DynamoDB.
+
+    This should be triggered after all worker Lambdas complete (e.g., via Step Functions
+    or a scheduled cleanup job).
+
+    Args:
+        event: Contains:
+            - job_id: The scraper job ID to process
+        context: Lambda context object
+
+    Returns:
+        Dict with processing results
+    """
+    job_id = event.get("job_id")
+    if not job_id:
+        return {
+            "statusCode": 400,
+            "body": json.dumps({"error": "job_id is required"}),
+        }
+
+    logger.info(f"Processing scraper results for job {job_id}")
+
+    stats = {
+        "job_id": job_id,
+        "resorts_added": 0,
+        "resorts_updated": 0,
+        "errors": 0,
+    }
+
+    try:
+        table = dynamodb.Table(RESORTS_TABLE)
+
+        # List all result files for this job
+        paginator = s3.get_paginator("list_objects_v2")
+        prefix = f"scraper-results/{job_id}/"
+
+        for page in paginator.paginate(Bucket=RESULTS_BUCKET, Prefix=prefix):
+            for obj in page.get("Contents", []):
+                key = obj["Key"]
+                if key.endswith("_metadata.json") or not key.endswith(".json"):
+                    continue
+
+                # Download and parse results
+                try:
+                    response = s3.get_object(Bucket=RESULTS_BUCKET, Key=key)
+                    data = json.loads(response["Body"].read().decode("utf-8"))
+                    resorts = data.get("resorts", [])
+
+                    for resort_data in resorts:
+                        try:
+                            # Convert to DynamoDB format
+                            item = convert_to_dynamodb_item(resort_data)
+                            table.put_item(Item=item)
+                            stats["resorts_added"] += 1
+                        except Exception as e:
+                            logger.error(
+                                f"Error adding resort {resort_data.get('resort_id')}: {e}"
+                            )
+                            stats["errors"] += 1
+
+                except Exception as e:
+                    logger.error(f"Error processing {key}: {e}")
+                    stats["errors"] += 1
+
+        logger.info(
+            f"Processed job {job_id}: "
+            f"{stats['resorts_added']} added, {stats['errors']} errors"
+        )
+
+        return {
+            "statusCode": 200,
+            "body": json.dumps(
+                {
+                    "message": f"Processed {stats['resorts_added']} resorts",
+                    "stats": stats,
+                }
+            ),
+        }
+
+    except Exception as e:
+        logger.error(f"Fatal error processing results: {str(e)}")
+        return {
+            "statusCode": 500,
+            "body": json.dumps({"error": str(e)}),
+        }
+
+
+def convert_to_dynamodb_item(resort_data: dict) -> dict:
+    """Convert scraped resort data to DynamoDB item format."""
+    now = datetime.now(UTC).isoformat()
+
+    # Calculate elevation points
+    base_m = resort_data["elevation_base_m"]
+    top_m = resort_data["elevation_top_m"]
+    mid_m = (base_m + top_m) // 2
+
+    lat = resort_data.get("latitude", 0.0)
+    lon = resort_data.get("longitude", 0.0)
+
+    elevation_points = [
+        {
+            "level": "base",
+            "elevation_meters": base_m,
+            "elevation_feet": int(base_m * 3.28084),
+            "latitude": lat,
+            "longitude": lon,
+        },
+        {
+            "level": "mid",
+            "elevation_meters": mid_m,
+            "elevation_feet": int(mid_m * 3.28084),
+            "latitude": lat + 0.002,
+            "longitude": lon - 0.003,
+        },
+        {
+            "level": "top",
+            "elevation_meters": top_m,
+            "elevation_feet": int(top_m * 3.28084),
+            "latitude": lat + 0.004,
+            "longitude": lon - 0.006,
+        },
+    ]
+
+    return {
+        "resort_id": resort_data["resort_id"],
+        "name": resort_data["name"],
+        "country": resort_data["country"],
+        "region": resort_data.get("region", "other"),
+        "elevation_points": elevation_points,
+        "timezone": get_timezone(
+            resort_data["country"], resort_data.get("state_province", "")
+        ),
+        "created_at": now,
+        "updated_at": now,
+        "source": resort_data.get("source"),
+        "scraped_at": resort_data.get("scraped_at"),
+    }
+
+
+def get_timezone(country: str, state_province: str) -> str:
+    """Get timezone for a resort based on country and state/province."""
+    timezone_map = {
+        "US": {
+            "CA": "America/Los_Angeles",
+            "OR": "America/Los_Angeles",
+            "WA": "America/Los_Angeles",
+            "CO": "America/Denver",
+            "UT": "America/Denver",
+            "WY": "America/Denver",
+            "MT": "America/Denver",
+            "VT": "America/New_York",
+            "NH": "America/New_York",
+            "ME": "America/New_York",
+            "NY": "America/New_York",
+            "_default": "America/Denver",
+        },
+        "CA": {
+            "BC": "America/Vancouver",
+            "AB": "America/Edmonton",
+            "ON": "America/Toronto",
+            "QC": "America/Montreal",
+            "_default": "America/Vancouver",
+        },
+        "FR": "Europe/Paris",
+        "CH": "Europe/Zurich",
+        "AT": "Europe/Vienna",
+        "IT": "Europe/Rome",
+        "DE": "Europe/Berlin",
+        "JP": "Asia/Tokyo",
+        "AU": "Australia/Sydney",
+        "NZ": "Pacific/Auckland",
+        "CL": "America/Santiago",
+        "AR": "America/Argentina/Buenos_Aires",
+        "NO": "Europe/Oslo",
+        "SE": "Europe/Stockholm",
+    }
+
+    if country in timezone_map:
+        tz = timezone_map[country]
+        if isinstance(tz, dict):
+            return tz.get(state_province, tz.get("_default", "UTC"))
+        return tz
+
+    return "UTC"

--- a/backend/src/handlers/scraper_worker.py
+++ b/backend/src/handlers/scraper_worker.py
@@ -1,0 +1,563 @@
+"""Lambda handler for scraping resorts from a specific country/region.
+
+This worker Lambda is invoked by the scraper orchestrator to process
+one country at a time, enabling parallel scraping across multiple Lambdas.
+"""
+
+import json
+import logging
+import os
+import re
+import time
+from datetime import UTC, datetime
+from typing import Any
+from urllib.parse import urljoin
+
+import boto3
+import requests
+from bs4 import BeautifulSoup
+
+# Configure logging
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
+
+# Initialize AWS clients
+dynamodb = boto3.resource("dynamodb")
+cloudwatch = boto3.client("cloudwatch")
+s3 = boto3.client("s3")
+
+# Environment variables
+ENVIRONMENT = os.environ.get("ENVIRONMENT", "dev")
+RESULTS_BUCKET = os.environ.get("RESULTS_BUCKET", "snow-tracker-pulumi-state-us-west-2")
+RESORTS_TABLE = os.environ.get("RESORTS_TABLE", "snow-tracker-resorts-dev")
+
+# Scraper constants
+USER_AGENT = (
+    "Mozilla/5.0 (compatible; SnowTrackerBot/1.0; +https://github.com/snowtracker)"
+)
+REQUEST_DELAY = 1.0  # Seconds between requests
+MAX_RETRIES = 3
+MIN_VERTICAL = 300  # Minimum vertical drop in meters
+
+# Country URL mappings for skiresort.info
+COUNTRY_URLS = {
+    "US": "/ski-resorts/usa",
+    "CA": "/ski-resorts/canada",
+    "AT": "/ski-resorts/austria",
+    "CH": "/ski-resorts/switzerland",
+    "FR": "/ski-resorts/france",
+    "IT": "/ski-resorts/italy",
+    "DE": "/ski-resorts/germany",
+    "SI": "/ski-resorts/slovenia",
+    "NO": "/ski-resorts/norway",
+    "SE": "/ski-resorts/sweden",
+    "FI": "/ski-resorts/finland",
+    "JP": "/ski-resorts/japan",
+    "AU": "/ski-resorts/australia",
+    "NZ": "/ski-resorts/new-zealand",
+    "CL": "/ski-resorts/chile",
+    "AR": "/ski-resorts/argentina",
+    "ES": "/ski-resorts/spain",
+    "AD": "/ski-resorts/andorra",
+    "PL": "/ski-resorts/poland",
+    "CZ": "/ski-resorts/czech-republic",
+    "SK": "/ski-resorts/slovakia",
+    "KR": "/ski-resorts/south-korea",
+    "CN": "/ski-resorts/china",
+}
+
+# Region mappings
+REGION_MAPPINGS = {
+    "FR": "alps",
+    "CH": "alps",
+    "AT": "alps",
+    "IT": "alps",
+    "DE": "alps",
+    "SI": "alps",
+    "AD": "alps",
+    "ES": "alps",
+    "NO": "scandinavia",
+    "SE": "scandinavia",
+    "FI": "scandinavia",
+    "US": "na_rockies",
+    "CA": "na_west",
+    "JP": "japan",
+    "AU": "oceania",
+    "NZ": "oceania",
+    "CL": "south_america",
+    "AR": "south_america",
+    "PL": "europe_east",
+    "CZ": "europe_east",
+    "SK": "europe_east",
+    "KR": "asia",
+    "CN": "asia",
+}
+
+# US state to region mapping
+US_STATE_REGIONS = {
+    "CA": "na_west",
+    "OR": "na_west",
+    "WA": "na_west",
+    "CO": "na_rockies",
+    "UT": "na_rockies",
+    "WY": "na_rockies",
+    "MT": "na_rockies",
+    "ID": "na_rockies",
+    "NM": "na_rockies",
+    "AZ": "na_rockies",
+    "NV": "na_rockies",
+    "VT": "na_east",
+    "NH": "na_east",
+    "ME": "na_east",
+    "NY": "na_east",
+    "PA": "na_east",
+    "MA": "na_east",
+    "MI": "na_midwest",
+    "WI": "na_midwest",
+    "MN": "na_midwest",
+}
+
+# Canadian province to region mapping
+CA_PROVINCE_REGIONS = {
+    "BC": "na_west",
+    "AB": "na_rockies",
+    "ON": "na_east",
+    "QC": "na_east",
+}
+
+
+class ScraperSession:
+    """HTTP session with rate limiting and retries."""
+
+    def __init__(self):
+        self.session = requests.Session()
+        self.session.headers.update({"User-Agent": USER_AGENT})
+        self._last_request_time = 0
+
+    def _rate_limit(self):
+        """Enforce rate limiting between requests."""
+        elapsed = time.time() - self._last_request_time
+        if elapsed < REQUEST_DELAY:
+            time.sleep(REQUEST_DELAY - elapsed)
+        self._last_request_time = time.time()
+
+    def get(self, url: str, **kwargs) -> requests.Response:
+        """Make a rate-limited GET request with retries."""
+        self._rate_limit()
+
+        for attempt in range(MAX_RETRIES):
+            try:
+                response = self.session.get(url, timeout=30, **kwargs)
+                response.raise_for_status()
+                return response
+            except requests.RequestException as e:
+                logger.warning(
+                    f"Request failed (attempt {attempt + 1}/{MAX_RETRIES}): {e}"
+                )
+                if attempt < MAX_RETRIES - 1:
+                    time.sleep(2**attempt)
+                else:
+                    raise
+
+        raise RuntimeError(f"Failed to fetch {url} after {MAX_RETRIES} attempts")
+
+    def get_soup(self, url: str, **kwargs) -> BeautifulSoup:
+        """Fetch URL and return BeautifulSoup object."""
+        response = self.get(url, **kwargs)
+        return BeautifulSoup(response.text, "html.parser")
+
+
+def get_region(country: str, state_province: str = "") -> str:
+    """Determine the region based on country and state/province."""
+    if country == "US" and state_province in US_STATE_REGIONS:
+        return US_STATE_REGIONS[state_province]
+    if country == "CA" and state_province in CA_PROVINCE_REGIONS:
+        return CA_PROVINCE_REGIONS[state_province]
+    return REGION_MAPPINGS.get(country, "other")
+
+
+def collect_resort_urls(session: ScraperSession, country: str) -> list[tuple[str, str]]:
+    """Collect all resort URLs from a country's listing pages."""
+    base_url = "https://www.skiresort.info"
+    url = urljoin(base_url, COUNTRY_URLS[country])
+    resort_urls = []
+    page = 1
+
+    while True:
+        page_url = f"{url}/page/{page}" if page > 1 else url
+
+        try:
+            soup = session.get_soup(page_url)
+        except requests.HTTPError as e:
+            if e.response.status_code == 404:
+                break
+            raise
+
+        # Find resort links
+        links = soup.select("a[href*='/ski-resort/']")
+        seen = set()
+        skip_patterns = [
+            "/snow-report",
+            "/test-report",
+            "/reviews",
+            "/photos",
+            "/webcams",
+            "/trail-map",
+        ]
+
+        for link in links:
+            href = link.get("href", "")
+            if any(pattern in href for pattern in skip_patterns):
+                continue
+            full_url = urljoin(base_url, href)
+            if "/ski-resort/" in full_url and full_url not in seen:
+                seen.add(full_url)
+                resort_urls.append((full_url, country))
+
+        # Check for next page
+        next_link = soup.select_one(".pagination .next, a[rel='next']")
+        if not next_link or page >= 20:
+            break
+        page += 1
+
+    return resort_urls
+
+
+def scrape_resort_detail(
+    session: ScraperSession, url: str, country: str
+) -> dict | None:
+    """Scrape detailed resort information from its page."""
+    try:
+        soup = session.get_soup(url)
+    except Exception as e:
+        logger.warning(f"Failed to fetch resort detail {url}: {e}")
+        return None
+
+    # Extract name
+    name_elem = soup.select_one("h1, .resort-name, .title")
+    if not name_elem:
+        return None
+    name = name_elem.get_text(strip=True)
+
+    # Clean name
+    name = re.sub(r"^(?:Ski resort |Ski Resort )", "", name, flags=re.IGNORECASE)
+    name = re.sub(r"\s*[-–]\s*Ski Resort.*$", "", name, flags=re.IGNORECASE)
+
+    # Skip non-resort pages
+    skip_prefixes = ["Snow report", "Test report", "Trail map", "Events", "Webcams"]
+    if any(name.lower().startswith(prefix.lower()) for prefix in skip_prefixes):
+        return None
+
+    # Extract elevation
+    elevation_base = None
+    elevation_top = None
+
+    all_elevations = re.findall(r"(\d{3,4})\s*m", soup.get_text())
+    all_elevations = [int(e) for e in all_elevations if 100 < int(e) < 5000]
+    if len(all_elevations) >= 2:
+        elevation_base = min(all_elevations)
+        elevation_top = max(all_elevations)
+
+    if not elevation_base or not elevation_top:
+        return None
+
+    # Check minimum vertical
+    if (elevation_top - elevation_base) < MIN_VERTICAL:
+        return None
+
+    # Extract state/province
+    state_province = extract_state_province(soup, country)
+
+    # Extract coordinates
+    latitude, longitude = extract_coordinates(soup)
+
+    # Generate resort ID
+    resort_id = generate_resort_id(name)
+
+    return {
+        "resort_id": resort_id,
+        "name": name,
+        "country": country,
+        "region": get_region(country, state_province),
+        "state_province": state_province,
+        "elevation_base_m": elevation_base,
+        "elevation_top_m": elevation_top,
+        "latitude": latitude,
+        "longitude": longitude,
+        "source": "skiresort.info",
+        "source_url": url,
+        "scraped_at": datetime.now(UTC).isoformat(),
+    }
+
+
+def extract_state_province(soup: BeautifulSoup, country: str) -> str:
+    """Extract state/province from the page."""
+    mobile_header = soup.select_one(".mobile-header-regionselector")
+    if mobile_header:
+        text = mobile_header.get_text()
+
+        if country == "US":
+            match = re.search(
+                r"USA([A-Z][a-z]+(?:\s[A-Z][a-z]+)*?)(?=[A-Z][a-z]|$)", text
+            )
+            if match:
+                state = match.group(1).strip()
+                if state not in ["Worldwide", "North", "Search"]:
+                    return state
+
+        if country == "CA":
+            match = re.search(
+                r"Canada([A-Z][a-z]+(?:\s[A-Z][a-z]+)*?)(?=[A-Z][a-z]|$)", text
+            )
+            if match:
+                province = match.group(1).strip()
+                if province not in ["Worldwide", "North", "Search"]:
+                    return province
+
+    return ""
+
+
+def extract_coordinates(soup: BeautifulSoup) -> tuple[float, float]:
+    """Extract coordinates from the page."""
+    # Try data attributes
+    map_elem = soup.select_one("[data-lat], [data-latitude]")
+    if map_elem:
+        lat = map_elem.get("data-lat") or map_elem.get("data-latitude")
+        lon = (
+            map_elem.get("data-lng")
+            or map_elem.get("data-lon")
+            or map_elem.get("data-longitude")
+        )
+        if lat and lon:
+            return float(lat), float(lon)
+
+    # Try scripts
+    for script in soup.find_all("script"):
+        if script.string:
+            lat_match = re.search(r"lat[itude]*[\"':\s]+(-?\d+\.?\d*)", script.string)
+            lng_match = re.search(
+                r"(?:lng|lon)[gitude]*[\"':\s]+(-?\d+\.?\d*)", script.string
+            )
+            if lat_match and lng_match:
+                return float(lat_match.group(1)), float(lng_match.group(1))
+
+    return 0.0, 0.0
+
+
+def generate_resort_id(name: str) -> str:
+    """Generate a URL-friendly resort ID from the name."""
+    resort_id = name.lower()
+    resort_id = re.sub(r"[''`]", "", resort_id)
+    resort_id = re.sub(r"[àáâãäå]", "a", resort_id)
+    resort_id = re.sub(r"[èéêë]", "e", resort_id)
+    resort_id = re.sub(r"[ìíîï]", "i", resort_id)
+    resort_id = re.sub(r"[òóôõö]", "o", resort_id)
+    resort_id = re.sub(r"[ùúûü]", "u", resort_id)
+    resort_id = re.sub(r"[^a-z0-9]+", "-", resort_id)
+    resort_id = resort_id.strip("-")
+    resort_id = re.sub(r"-+", "-", resort_id)
+    return resort_id
+
+
+def get_existing_resort_ids() -> set[str]:
+    """Get set of existing resort IDs from DynamoDB."""
+    table = dynamodb.Table(RESORTS_TABLE)
+    existing_ids = set()
+
+    try:
+        response = table.scan(ProjectionExpression="resort_id")
+        existing_ids.update(item["resort_id"] for item in response.get("Items", []))
+
+        while "LastEvaluatedKey" in response:
+            response = table.scan(
+                ProjectionExpression="resort_id",
+                ExclusiveStartKey=response["LastEvaluatedKey"],
+            )
+            existing_ids.update(item["resort_id"] for item in response.get("Items", []))
+
+    except Exception as e:
+        logger.warning(f"Failed to fetch existing resort IDs: {e}")
+
+    return existing_ids
+
+
+def publish_metrics(stats: dict[str, Any], country: str) -> None:
+    """Publish scraper metrics to CloudWatch."""
+    try:
+        metrics = [
+            {
+                "MetricName": "ResortsScraped",
+                "Value": stats.get("resorts_scraped", 0),
+                "Unit": "Count",
+                "Dimensions": [
+                    {"Name": "Environment", "Value": ENVIRONMENT},
+                    {"Name": "Country", "Value": country},
+                ],
+            },
+            {
+                "MetricName": "ResortsSkipped",
+                "Value": stats.get("resorts_skipped", 0),
+                "Unit": "Count",
+                "Dimensions": [
+                    {"Name": "Environment", "Value": ENVIRONMENT},
+                    {"Name": "Country", "Value": country},
+                ],
+            },
+            {
+                "MetricName": "ScraperErrors",
+                "Value": stats.get("errors", 0),
+                "Unit": "Count",
+                "Dimensions": [
+                    {"Name": "Environment", "Value": ENVIRONMENT},
+                    {"Name": "Country", "Value": country},
+                ],
+            },
+            {
+                "MetricName": "ScraperDuration",
+                "Value": stats.get("duration_seconds", 0),
+                "Unit": "Seconds",
+                "Dimensions": [
+                    {"Name": "Environment", "Value": ENVIRONMENT},
+                    {"Name": "Country", "Value": country},
+                ],
+            },
+        ]
+
+        cloudwatch.put_metric_data(Namespace="SnowTracker/Scraper", MetricData=metrics)
+        logger.info(f"Published scraper metrics for {country}")
+
+    except Exception as e:
+        logger.error(f"Failed to publish scraper metrics: {e}")
+
+
+def scraper_worker_handler(event: dict[str, Any], context) -> dict[str, Any]:
+    """
+    Lambda handler for scraping resorts from a specific country.
+
+    Args:
+        event: Contains:
+            - country: Country code to scrape (e.g., "US", "CA", "FR")
+            - delta_mode: If true, skip existing resorts (default: true)
+            - job_id: Unique job ID for storing results
+        context: Lambda context object
+
+    Returns:
+        Dict with scraping results
+    """
+    country = event.get("country")
+    delta_mode = event.get("delta_mode", True)
+    job_id = event.get("job_id", datetime.now(UTC).strftime("%Y%m%d%H%M%S"))
+
+    if not country or country not in COUNTRY_URLS:
+        return {
+            "statusCode": 400,
+            "body": json.dumps({"error": f"Invalid country: {country}"}),
+        }
+
+    logger.info(f"Starting scrape for country {country}, delta_mode={delta_mode}")
+
+    stats = {
+        "country": country,
+        "resorts_scraped": 0,
+        "resorts_skipped": 0,
+        "errors": 0,
+        "start_time": datetime.now(UTC).isoformat(),
+    }
+
+    try:
+        session = ScraperSession()
+
+        # Get existing resort IDs for delta mode
+        existing_ids = get_existing_resort_ids() if delta_mode else set()
+        if existing_ids:
+            logger.info(
+                f"Delta mode: {len(existing_ids)} existing resorts will be skipped"
+            )
+
+        # Collect resort URLs
+        logger.info(f"Collecting resort URLs for {country}...")
+        resort_urls = collect_resort_urls(session, country)
+        logger.info(f"Found {len(resort_urls)} resort URLs")
+
+        # Scrape each resort
+        scraped_resorts = []
+        for url, country_code in resort_urls:
+            try:
+                # Check if already exists in delta mode
+                url_id = url.split("/ski-resort/")[-1].rstrip("/")
+                if delta_mode and url_id in existing_ids:
+                    stats["resorts_skipped"] += 1
+                    continue
+
+                resort = scrape_resort_detail(session, url, country_code)
+                if resort:
+                    # Double-check ID doesn't exist
+                    if delta_mode and resort["resort_id"] in existing_ids:
+                        stats["resorts_skipped"] += 1
+                        continue
+
+                    scraped_resorts.append(resort)
+                    stats["resorts_scraped"] += 1
+                    logger.info(f"Scraped: {resort['name']}")
+
+            except Exception as e:
+                logger.error(f"Error scraping {url}: {e}")
+                stats["errors"] += 1
+
+        stats["end_time"] = datetime.now(UTC).isoformat()
+        stats["duration_seconds"] = (
+            datetime.fromisoformat(stats["end_time"].replace("Z", "+00:00"))
+            - datetime.fromisoformat(stats["start_time"].replace("Z", "+00:00"))
+        ).total_seconds()
+
+        # Store results in S3
+        if scraped_resorts:
+            results_key = f"scraper-results/{job_id}/{country}.json"
+            s3.put_object(
+                Bucket=RESULTS_BUCKET,
+                Key=results_key,
+                Body=json.dumps({"resorts": scraped_resorts, "stats": stats}),
+                ContentType="application/json",
+            )
+            logger.info(
+                f"Stored {len(scraped_resorts)} resorts to s3://{RESULTS_BUCKET}/{results_key}"
+            )
+
+        # Publish metrics
+        publish_metrics(stats, country)
+
+        logger.info(
+            f"Scrape complete for {country}: "
+            f"{stats['resorts_scraped']} scraped, "
+            f"{stats['resorts_skipped']} skipped, "
+            f"{stats['errors']} errors"
+        )
+
+        return {
+            "statusCode": 200,
+            "body": json.dumps(
+                {
+                    "message": f"Scraped {stats['resorts_scraped']} resorts from {country}",
+                    "country": country,
+                    "resorts_scraped": stats["resorts_scraped"],
+                    "resorts_skipped": stats["resorts_skipped"],
+                    "errors": stats["errors"],
+                    "duration_seconds": stats["duration_seconds"],
+                }
+            ),
+        }
+
+    except Exception as e:
+        logger.error(f"Fatal error scraping {country}: {str(e)}")
+        stats["errors"] += 1
+
+        return {
+            "statusCode": 500,
+            "body": json.dumps(
+                {
+                    "message": f"Scraper failed for {country}",
+                    "error": str(e),
+                    "stats": stats,
+                }
+            ),
+        }


### PR DESCRIPTION
## Summary
- Adds parallel Lambda-based resort scraping architecture
- Orchestrator Lambda fans out to worker Lambdas (one per country, 23 countries)
- Workers scrape resorts from skiresort.info with rate limiting and retry logic
- Delta mode (daily): only scrape new resorts
- Full scrape (1st of month): refresh all resort data
- Results stored in S3, processed by separate handler into DynamoDB

## Key Components
- `scraper_orchestrator.py`: Dispatches workers for each country (async invocation)
- `scraper_worker.py`: Scrapes resorts for a single country from skiresort.info
- CloudWatch Events schedule (daily 6 AM UTC)
- CloudWatch metrics for monitoring

## Test plan
- [ ] Deploy to staging
- [ ] Manually invoke orchestrator Lambda
- [ ] Verify worker Lambdas are triggered
- [ ] Check CloudWatch logs for scraper progress
- [ ] Verify results are stored in S3

Closes #91

🤖 Generated with [Claude Code](https://claude.com/claude-code)