### PR TITLE
Add SNS notifications for newly discovered resorts

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -287,6 +287,7 @@ jobs:
 
         # Deploy Scraper Worker Lambda
         SCRAPER_WORKER=$(pulumi stack output scraper_worker_lambda_name 2>/dev/null || echo "")
+        NEW_RESORTS_TOPIC=$(pulumi stack output new_resorts_topic_arn 2>/dev/null || echo "")
         if [ -n "$SCRAPER_WORKER" ]; then
           echo "Deploying Scraper worker Lambda: $SCRAPER_WORKER"
           aws lambda update-function-code \
@@ -299,7 +300,7 @@ jobs:
           # Update Scraper Worker Lambda environment variables
           aws lambda update-function-configuration \
             --function-name "$SCRAPER_WORKER" \
-            --environment "Variables={ENVIRONMENT=${{ env.ENVIRONMENT }},RESORTS_TABLE=snow-tracker-resorts-${{ env.ENVIRONMENT }},RESULTS_BUCKET=snow-tracker-pulumi-state-us-west-2,AWS_REGION_NAME=us-west-2}" \
+            --environment "Variables={ENVIRONMENT=${{ env.ENVIRONMENT }},RESORTS_TABLE=snow-tracker-resorts-${{ env.ENVIRONMENT }},RESULTS_BUCKET=snow-tracker-pulumi-state-us-west-2,AWS_REGION_NAME=us-west-2,NEW_RESORTS_TOPIC_ARN=$NEW_RESORTS_TOPIC}" \
             --region us-west-2
           aws lambda wait function-updated --function-name "$SCRAPER_WORKER" --region us-west-2
           echo "Scraper worker Lambda updated"


### PR DESCRIPTION
## Summary
- Adds SNS topic for new resort notifications from scraper
- Scraper worker publishes message when new resorts are discovered
- Email subscription in prod environment
- Includes resort details: name, region, vertical drop

## Infrastructure Changes
- New SNS topic: `snow-tracker-new-resorts-{env}`
- Email subscription (prod only)
- Scraper worker Lambda gets `NEW_RESORTS_TOPIC_ARN` env var

## Test plan
- [ ] Deploy to staging
- [ ] Manually invoke scraper with a test country
- [ ] Verify SNS message is published (check CloudWatch logs)
- [ ] In prod, verify email is received when new resorts found

🤖 Generated with [Claude Code](https://claude.com/claude-code)