### PR TITLE
Fix API connectivity: use API Gateway URLs directly

### DIFF
--- a/ios/SnowTracker/SnowTracker/Sources/Services/Configuration.swift
+++ b/ios/SnowTracker/SnowTracker/Sources/Services/Configuration.swift
@@ -28,18 +28,15 @@ enum AppEnvironment: String, CaseIterable {
     }
 
     /// API base URL for each environment
-    /// Using custom subdomains of powderchaserapp.com
+    /// Using API Gateway URLs directly (custom domain DNS is not resolving)
     var apiBaseURL: URL {
         switch self {
         case .development:
-            // Dev environment - use dev subdomain
-            return URL(string: "https://dev.api.powderchaserapp.com")!
+            return URL(string: "https://mhserjdtp1.execute-api.us-west-2.amazonaws.com/staging")!
         case .staging:
-            // Staging subdomain
-            return URL(string: "https://staging.api.powderchaserapp.com")!
+            return URL(string: "https://mhserjdtp1.execute-api.us-west-2.amazonaws.com/staging")!
         case .production:
-            // Production API
-            return URL(string: "https://api.powderchaserapp.com")!
+            return URL(string: "https://z1f5zrp4l0.execute-api.us-west-2.amazonaws.com/prod")!
         }
     }
 


### PR DESCRIPTION
## Summary
- Replace custom domain URLs (`*.api.powderchaserapp.com`) with direct API Gateway URLs in iOS app configuration
- Custom domain DNS is not resolving, so the app was unable to reach the backend
- Updates all three environments (development, staging, production) in `Configuration.swift`

## Changes
- **`ios/SnowTracker/SnowTracker/Sources/Services/Configuration.swift`**: Updated `apiBaseURL` for all `AppEnvironment` cases to use working API Gateway endpoints instead of unresolvable custom subdomain URLs

## Test plan
- [x] Unit tests pass
- [ ] Verify API calls succeed on physical device with updated URLs

🤖 Generated with [Claude Code](https://claude.com/claude-code)