### PR TITLE
Fix API custom domain DNS resolution

### DIFF
--- a/infrastructure/__main__.py
+++ b/infrastructure/__main__.py
@@ -2088,6 +2088,7 @@ if enable_custom_domain:
         type=api_regional_cert.domain_validation_options[0].resource_record_type,
         records=[api_regional_cert.domain_validation_options[0].resource_record_value],
         ttl=300,
+        allow_overwrite=True,
     )
 
     api_cert_validation = aws.acm.CertificateValidation(


### PR DESCRIPTION
## Summary
- Add `allow_overwrite=True` to the API certificate validation DNS record in Pulumi infrastructure
- This fixes the root cause of `api.powderchaserapp.com` not resolving: the cert validation DNS record fails to create when it already exists in Route53
- The CloudFront cert validation record already had this flag (line 1894), but the API cert validation record was missing it

## Context
- PR #101 attempted to work around this by switching the iOS app to use API Gateway URLs directly
- This PR fixes the infrastructure root cause instead, so the custom domain URLs work correctly
- No iOS app changes needed - the app already uses the correct custom domain URLs

## Test plan
- [x] Python syntax validation passes
- [ ] CI passes
- [ ] Pulumi preview shows only the `allow_overwrite` addition
- [ ] After merge & deploy: `api.powderchaserapp.com` resolves correctly
- [ ] After merge & deploy: iOS app can reach the API via custom domain

🤖 Generated with [Claude Code](https://claude.com/claude-code)