### PR TITLE
Improve startup performance with instant cache loading and consistent snow quality

### DIFF
--- a/ios/SnowTracker.xcodeproj/project.pbxproj
+++ b/ios/SnowTracker.xcodeproj/project.pbxproj
@@ -51,6 +51,7 @@
 		C0711EC616F41F08730D790A /* FavoritesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E48E349AAA6C4BEDDCD317E /* FavoritesView.swift */; };
 		C440EFF2F7868A9A09A525C2 /* Configuration.swift in Sources */ = {isa = PBXBuildFile; fileRef = A882E15FD24B57516DE0B29E /* Configuration.swift */; };
 		C9503A1D14E11C37EBD585F7 /* GoogleSignInSwift in Frameworks */ = {isa = PBXBuildFile; productRef = BFEBBB03F51632FE030398C0 /* GoogleSignInSwift */; };
+		CA425D6DF761A30E14DAF304 /* GoogleService-Info.plist.template in Resources */ = {isa = PBXBuildFile; fileRef = C9D8809765B1DAE070C75605 /* GoogleService-Info.plist.template */; };
 		CB46CD3F06EA5CAB49652FC8 /* MapViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 137A889DFFD57B2095D78866 /* MapViewModel.swift */; };
 		CCD8A0284D887301091D486F /* TripPlanningViews.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34B3DE91A8041E068949717A /* TripPlanningViews.swift */; };
 		CE8B411E66E77DAF8A7FB715 /* ResortDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22ECDCF89993D8220437C43C /* ResortDetailView.swift */; };
@@ -146,6 +147,7 @@
 		C195DDF1D0D05A96F34D77AC /* SnapshotHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SnapshotHelper.swift; sourceTree = "<group>"; };
 		C1CD2C514C419D7264FB7E0D /* SnowTrackerApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SnowTrackerApp.swift; sourceTree = "<group>"; };
 		C8A4D65C5E4661E9DBBBB32F /* AppStoreScreenshotTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStoreScreenshotTests.swift; sourceTree = "<group>"; };
+		C9D8809765B1DAE070C75605 /* GoogleService-Info.plist.template */ = {isa = PBXFileReference; path = "GoogleService-Info.plist.template"; sourceTree = "<group>"; };
 		CF54F2EE12C18F789C609199 /* zh-Hans */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-Hans"; path = "zh-Hans.lproj/Localizable.strings"; sourceTree = "<group>"; };
 		D08B0D7A69AC7F3C0A29887D /* WidgetModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WidgetModels.swift; sourceTree = "<group>"; };
 		D23B988BBFF873484906C493 /* AuthenticationService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthenticationService.swift; sourceTree = "<group>"; };
@@ -280,7 +282,6 @@
 			children = (
 				BE115A7AABCC32A18E3ACBF1 /* Models */,
 				285960ACA67185390B9A0DFC /* Services */,
-				AE770580F728A11A4FE34122 /* Utils */,
 				1E3908A7EEE6BA35E8EA44FB /* ViewModels */,
 				2B26478395424C45EDF16B48 /* Views */,
 				C1CD2C514C419D7264FB7E0D /* SnowTrackerApp.swift */,
@@ -306,17 +307,11 @@
 			children = (
 				9DA3C8E41208AE034CEF3110 /* Assets.xcassets */,
 				D306BA8EC8E75B251574AF45 /* GoogleService-Info.plist */,
+				C9D8809765B1DAE070C75605 /* GoogleService-Info.plist.template */,
 				F3EC6FA3AFD9ECE413C5A241 /* Localizable.strings */,
 			);
 			name = Resources;
 			path = SnowTracker/SnowTracker/Resources;
-			sourceTree = "<group>";
-		};
-		AE770580F728A11A4FE34122 /* Utils */ = {
-			isa = PBXGroup;
-			children = (
-			);
-			path = Utils;
 			sourceTree = "<group>";
 		};
 		BE115A7AABCC32A18E3ACBF1 /* Models */ = {
@@ -482,6 +477,7 @@
 			files = (
 				75E9966D6DAC958DE49B8269 /* Assets.xcassets in Resources */,
 				A559B6F611A845A81B6E08EF /* GoogleService-Info.plist in Resources */,
+				CA425D6DF761A30E14DAF304 /* GoogleService-Info.plist.template in Resources */,
 				DE52E62806A7F2BDDCC1E5C1 /* Localizable.strings in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -665,7 +661,7 @@
 				CODE_SIGN_ENTITLEMENTS = SnowTracker/SnowTracker.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 4;
+				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = N324UX8D9M;
 				INFOPLIST_FILE = SnowTracker/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -817,7 +813,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = SnowTrackerWidget/SnowTrackerWidget.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 4;
+				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = N324UX8D9M;
 				INFOPLIST_FILE = SnowTrackerWidget/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -841,7 +837,7 @@
 				CODE_SIGN_ENTITLEMENTS = SnowTracker/SnowTracker.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 4;
+				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = N324UX8D9M;
 				INFOPLIST_FILE = SnowTracker/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -862,7 +858,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = SnowTrackerWidget/SnowTrackerWidget.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 4;
+				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = N324UX8D9M;
 				INFOPLIST_FILE = SnowTrackerWidget/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (

--- a/ios/SnowTracker/Info.plist
+++ b/ios/SnowTracker/Info.plist
@@ -28,7 +28,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>4</string>
+	<string>1</string>
 	<key>GIDClientID</key>
 	<string>269334695221-p2i31pdp3n7ms7o7rpf6cb3vsdmc4ohs.apps.googleusercontent.com</string>
 	<key>ITSAppUsesNonExemptEncryption</key>

--- a/ios/SnowTracker/SnowTracker/Sources/Models/WeatherCondition.swift
+++ b/ios/SnowTracker/SnowTracker/Sources/Models/WeatherCondition.swift
@@ -152,7 +152,7 @@ enum SnowQuality: String, CaseIterable, Codable, Sendable {
             )
         case .good:
             return (
-                title: "Good - Soft Surface",
+                title: "Good - Fresh Snow",
                 description: "2+ inches of non-refrozen snow. Surface hasn't iced over. Enjoyable skiing on and off-piste.",
                 criteria: "2-3 inches (5-7.6 cm) of snow since last thaw-freeze, temps staying cold"
             )

--- a/ios/SnowTracker/SnowTracker/Sources/Views/ConditionsView.swift
+++ b/ios/SnowTracker/SnowTracker/Sources/Views/ConditionsView.swift
@@ -145,7 +145,7 @@ struct ResortConditionCard: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 12) {
-            // Header
+            // Header - use overall quality from summary for consistency
             HStack {
                 VStack(alignment: .leading) {
                     Text(resort.name)
@@ -158,15 +158,16 @@ struct ResortConditionCard: View {
 
                 Spacer()
 
-                if let condition = topCondition {
+                let displayQuality = snowConditionsManager.getSnowQuality(for: resort.id)
+                if displayQuality != .unknown {
                     VStack {
-                        Image(systemName: condition.snowQuality.icon)
+                        Image(systemName: displayQuality.icon)
                             .font(.title2)
-                            .foregroundColor(condition.snowQuality.color)
-                        Text(condition.snowQuality.displayName)
+                            .foregroundColor(displayQuality.color)
+                        Text(displayQuality.displayName)
                             .font(.caption)
                             .fontWeight(.semibold)
-                            .foregroundColor(condition.snowQuality.color)
+                            .foregroundColor(displayQuality.color)
                     }
                 }
             }

--- a/ios/SnowTracker/SnowTracker/Sources/Views/FavoritesView.swift
+++ b/ios/SnowTracker/SnowTracker/Sources/Views/FavoritesView.swift
@@ -102,16 +102,17 @@ struct FavoriteResortRow: View {
 
     var body: some View {
         HStack(spacing: 12) {
-            // Snow quality indicator
-            if let condition = topCondition {
+            // Snow quality indicator - use overall quality for consistency
+            let displayQuality = snowConditionsManager.getSnowQuality(for: resort.id)
+            if displayQuality != .unknown {
                 ZStack {
                     Circle()
-                        .fill(condition.snowQuality.color.opacity(0.2))
+                        .fill(displayQuality.color.opacity(0.2))
                         .frame(width: 50, height: 50)
 
-                    Image(systemName: condition.snowQuality.icon)
+                    Image(systemName: displayQuality.icon)
                         .font(.title2)
-                        .foregroundColor(condition.snowQuality.color)
+                        .foregroundColor(displayQuality.color)
                 }
             } else {
                 ZStack {

--- a/ios/SnowTracker/SnowTracker/Sources/Views/ResortDetailView.swift
+++ b/ios/SnowTracker/SnowTracker/Sources/Views/ResortDetailView.swift
@@ -117,6 +117,13 @@ struct ResortDetailView: View {
 
     // MARK: - Resort Header
 
+    /// Best quality across all loaded elevations (used for header badge)
+    private var bestElevationQuality: SnowQuality? {
+        let qualities = conditions.map { $0.snowQuality }
+        guard !qualities.isEmpty else { return nil }
+        return qualities.min(by: { $0.sortOrder < $1.sortOrder })
+    }
+
     private var resortHeader: some View {
         VStack(spacing: 8) {
             HStack {
@@ -132,21 +139,21 @@ struct ResortDetailView: View {
 
                 Spacer()
 
-                // Overall snow quality badge
-                if let condition = conditions.first {
+                // Overall snow quality badge - use best quality across elevations
+                if let quality = bestElevationQuality {
                     VStack {
-                        Image(systemName: condition.snowQuality.icon)
+                        Image(systemName: quality.icon)
                             .font(.title)
-                            .foregroundColor(condition.snowQuality.color)
-                        Text(condition.snowQuality.displayName)
+                            .foregroundColor(quality.color)
+                        Text(quality.displayName)
                             .font(.caption)
                             .fontWeight(.semibold)
-                            .foregroundColor(condition.snowQuality.color)
+                            .foregroundColor(quality.color)
                     }
                     .padding()
                     .background(
                         RoundedRectangle(cornerRadius: 12)
-                            .fill(condition.snowQuality.color.opacity(0.1))
+                            .fill(quality.color.opacity(0.1))
                     )
                 }
             }

--- a/ios/SnowTracker/SnowTracker/Sources/Views/ResortListView.swift
+++ b/ios/SnowTracker/SnowTracker/Sources/Views/ResortListView.swift
@@ -326,8 +326,9 @@ struct ResortRowView: View {
 
                 Spacer()
 
-                // Snow quality indicator - use condition if available, else check summary
-                let displayQuality = latestCondition?.snowQuality ?? snowConditionsManager.getSnowQuality(for: resort.id)
+                // Snow quality indicator - always use summary/overall quality for consistency
+                // (latestCondition is a single elevation which may differ from overall)
+                let displayQuality = snowConditionsManager.getSnowQuality(for: resort.id)
                 if displayQuality != .unknown {
                     VStack {
                         Image(systemName: displayQuality.icon)

--- a/ios/SnowTracker/SnowTracker/Sources/Views/ResortMapView.swift
+++ b/ios/SnowTracker/SnowTracker/Sources/Views/ResortMapView.swift
@@ -718,8 +718,8 @@ struct ClusterResortListSheet: View {
 
     private var sortedResorts: [Resort] {
         resorts.sorted { resort1, resort2 in
-            let quality1 = snowConditionsManager.getLatestCondition(for: resort1.id)?.snowQuality ?? .unknown
-            let quality2 = snowConditionsManager.getLatestCondition(for: resort2.id)?.snowQuality ?? .unknown
+            let quality1 = snowConditionsManager.getSnowQuality(for: resort1.id)
+            let quality2 = snowConditionsManager.getSnowQuality(for: resort2.id)
             if quality1.sortOrder != quality2.sortOrder {
                 return quality1.sortOrder < quality2.sortOrder
             }

--- a/ios/SnowTracker/SnowTrackerTests/SnowTrackerTests.swift
+++ b/ios/SnowTracker/SnowTrackerTests/SnowTrackerTests.swift
@@ -134,7 +134,7 @@ final class SnowTrackerTests: XCTestCase {
         let bigWhite = Resort.sampleResorts.first { $0.id == "big-white" }
         let topElevation = bigWhite?.topElevation
         XCTAssertNotNil(topElevation)
-        XCTAssertEqual(topElevation?.formattedElevation, "7608ft (2319m)")
+        XCTAssertEqual(topElevation?.formattedElevation, "7,608 ft (2,319 m)")
     }
 
     func testElevationPointCoordinate() {

--- a/ios/SnowTrackerWidget/Info.plist
+++ b/ios/SnowTrackerWidget/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>1.0.0</string>
 	<key>CFBundleVersion</key>
-	<string>4</string>
+	<string>1</string>
 	<key>NSExtension</key>
 	<dict>
 		<key>NSExtensionPointIdentifier</key>


### PR DESCRIPTION
## Summary
- **Instant startup**: Load cached resorts, snow quality summaries, and favorite conditions synchronously so the UI is populated immediately instead of showing a loading spinner
- **Prefetch all conditions**: Fetch conditions for all resorts in the background (not just favorites) so detail views have data ready without lazy loading
- **Consistent snow quality display**: Use overall/best quality across all views (list, map, conditions, favorites, detail) instead of quality from a single arbitrary elevation
- **Test updates**: Update API integration tests to match wrapped response format, fix elevation formatting assertion, relax CORS test for non-browser contexts, remove obsolete batch limit test
- **Minor cleanup**: Rename "Good - Soft Surface" to "Good - Fresh Snow", reset bundle version, remove empty Utils group

## Test plan
- [x] Unit tests pass
- [x] API integration tests updated for wrapped response format
- [ ] Verify startup shows cached data instantly on device
- [ ] Verify snow quality badges are consistent across all views
- [ ] Verify detail views load without additional spinner

🤖 Generated with [Claude Code](https://claude.com/claude-code)