### PR TITLE
Fix iOS build: enable automatic provisioning profile download

### DIFF
--- a/.github/workflows/ios-build.yml
+++ b/.github/workflows/ios-build.yml
@@ -31,4 +31,5 @@ jobs:
       xcodegen_path: ios
       info_plist_path: ios/SnowTracker/Info.plist
       additional_info_plists: 'ios/SnowTrackerWidget/Info.plist'
+      skip_automatic_signing: false
     secrets: inherit


### PR DESCRIPTION
## Summary
- Fixes the iOS build archive step which has been failing on `main` with "No profiles found" errors
- The shared workflow's `skip_automatic_signing` defaults to `true`, which prevents `-allowProvisioningUpdates` from being passed to xcodebuild
- Without this flag, Xcode can't automatically download provisioning profiles via the App Store Connect API key
- Sets `skip_automatic_signing: false` to enable automatic profile downloading

## Root Cause
The error was:
```
No profiles for 'com.wouterdevriendt.snowtracker.widget' were found: Automatic signing is disabled and unable to generate a profile.
No profiles for 'com.wouterdevriendt.snowtracker' were found: Automatic signing is disabled and unable to generate a profile.
```

## Test plan
- [ ] Verify iOS Build workflow succeeds on this PR (archive step is skipped for PRs, so check on main after merge)
- [ ] Trigger iOS TestFlight Internal after merge to confirm full pipeline works

🤖 Generated with [Claude Code](https://claude.com/claude-code)