### PR TITLE
Fix iOS build: reuse existing certs via ASC API

### DIFF
--- a/.github/workflows/ios-build.yml
+++ b/.github/workflows/ios-build.yml
@@ -1,6 +1,8 @@
 name: iOS Build
 
-# Uses shared workflow from ios-infra for building the iOS app
+# Inline build workflow (mirrors footprint approach) to avoid certificate
+# creation issues with the shared ios-infra workflow.
+# Uses App Store Connect API for automatic signing without creating new certs.
 
 on:
   push:
@@ -20,16 +22,174 @@ concurrency:
   group: ios-build-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+  actions: read
+
+env:
+  TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+
 jobs:
   build:
-    uses: wdvr/ios-infra/.github/workflows/ios-build.yml@main
-    with:
-      bundle_id: com.wouterdevriendt.snowtracker
-      scheme: SnowTracker
-      project_path: ios/SnowTracker.xcodeproj
-      use_xcodegen: true
-      xcodegen_path: ios
-      info_plist_path: ios/SnowTracker/Info.plist
-      additional_info_plists: 'ios/SnowTrackerWidget/Info.plist'
-      skip_automatic_signing: false
-    secrets: inherit
+    name: Build & Archive
+    runs-on: macos-15
+    timeout-minutes: 30
+    outputs:
+      build_number: ${{ steps.version.outputs.build }}
+      version: ${{ steps.version.outputs.version }}
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+
+    - name: Select Xcode
+      run: |
+        XCODE_PATH=$(ls -d /Applications/Xcode_26*.app 2>/dev/null | sort -V | tail -1)
+        if [ -z "$XCODE_PATH" ]; then
+          XCODE_PATH=$(ls -d /Applications/Xcode*.app 2>/dev/null | sort -V | tail -1)
+        fi
+        if [ -z "$XCODE_PATH" ]; then
+          XCODE_PATH="/Applications/Xcode.app"
+        fi
+
+        if [ -d "$XCODE_PATH" ]; then
+          echo "Using Xcode: $XCODE_PATH"
+          sudo xcode-select -s "$XCODE_PATH/Contents/Developer" || true
+        else
+          echo "Using default Xcode"
+        fi
+        xcodebuild -version
+
+    - name: Install XcodeGen
+      run: which xcodegen || brew install xcodegen
+
+    - name: Generate Xcode project
+      run: |
+        cd ios
+        xcodegen generate
+
+    - name: Resolve Swift Package Dependencies
+      run: |
+        xcodebuild -resolvePackageDependencies \
+          -project ios/SnowTracker.xcodeproj \
+          -scheme SnowTracker
+
+    - name: Calculate build number
+      id: version
+      run: |
+        BUILD=$(git rev-list --count HEAD)
+        PLIST="ios/SnowTracker/Info.plist"
+        VERSION=$(/usr/libexec/PlistBuddy -c "Print :CFBundleShortVersionString" "$PLIST" 2>/dev/null || echo "1.0.0")
+
+        # Update build number in main Info.plist
+        /usr/libexec/PlistBuddy -c "Set :CFBundleVersion $BUILD" "$PLIST" 2>/dev/null || \
+        /usr/libexec/PlistBuddy -c "Add :CFBundleVersion string $BUILD" "$PLIST"
+
+        # Update widget Info.plist
+        WIDGET_PLIST="ios/SnowTrackerWidget/Info.plist"
+        if [ -f "$WIDGET_PLIST" ]; then
+          /usr/libexec/PlistBuddy -c "Set :CFBundleVersion $BUILD" "$WIDGET_PLIST" 2>/dev/null || true
+          /usr/libexec/PlistBuddy -c "Set :CFBundleShortVersionString $VERSION" "$WIDGET_PLIST" 2>/dev/null || true
+        fi
+
+        echo "version=$VERSION" >> $GITHUB_OUTPUT
+        echo "build=$BUILD" >> $GITHUB_OUTPUT
+        echo "Building version $VERSION ($BUILD)"
+
+    - name: Setup App Store Connect API Key
+      if: github.event_name != 'pull_request'
+      run: |
+        mkdir -p $RUNNER_TEMP/private_keys
+        echo "${{ secrets.APP_STORE_CONNECT_PRIVATE_KEY }}" | tr -d '\r' > $RUNNER_TEMP/private_keys/AuthKey_${{ secrets.APP_STORE_CONNECT_KEY_ID }}.p8
+        chmod 600 $RUNNER_TEMP/private_keys/AuthKey_${{ secrets.APP_STORE_CONNECT_KEY_ID }}.p8
+
+    - name: Build (PR - no signing)
+      if: github.event_name == 'pull_request'
+      run: |
+        xcodebuild build \
+          -project ios/SnowTracker.xcodeproj \
+          -scheme SnowTracker \
+          -configuration Release \
+          -destination 'generic/platform=iOS' \
+          CODE_SIGNING_ALLOWED=NO
+
+    - name: Archive app
+      if: github.event_name != 'pull_request'
+      run: |
+        xcodebuild archive \
+          -project ios/SnowTracker.xcodeproj \
+          -scheme SnowTracker \
+          -configuration Release \
+          -archivePath $RUNNER_TEMP/Export/App.xcarchive \
+          -destination 'generic/platform=iOS' \
+          -allowProvisioningUpdates \
+          -authenticationKeyPath $RUNNER_TEMP/private_keys/AuthKey_${{ secrets.APP_STORE_CONNECT_KEY_ID }}.p8 \
+          -authenticationKeyID ${{ secrets.APP_STORE_CONNECT_KEY_ID }} \
+          -authenticationKeyIssuerID ${{ secrets.APP_STORE_CONNECT_ISSUER_ID }} \
+          CODE_SIGN_STYLE=Automatic \
+          DEVELOPMENT_TEAM=${{ env.TEAM_ID }}
+
+    - name: Create ExportOptions.plist
+      if: github.event_name != 'pull_request'
+      run: |
+        cat > /tmp/ExportOptions.plist << EOF
+        <?xml version="1.0" encoding="UTF-8"?>
+        <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+        <plist version="1.0">
+        <dict>
+            <key>method</key>
+            <string>app-store-connect</string>
+            <key>teamID</key>
+            <string>${{ env.TEAM_ID }}</string>
+            <key>signingStyle</key>
+            <string>automatic</string>
+            <key>uploadSymbols</key>
+            <true/>
+            <key>destination</key>
+            <string>export</string>
+        </dict>
+        </plist>
+        EOF
+
+    - name: Export IPA
+      if: github.event_name != 'pull_request'
+      run: |
+        xcodebuild -exportArchive \
+          -archivePath $RUNNER_TEMP/Export/App.xcarchive \
+          -exportPath $RUNNER_TEMP/Export \
+          -exportOptionsPlist /tmp/ExportOptions.plist \
+          -allowProvisioningUpdates \
+          -authenticationKeyPath $RUNNER_TEMP/private_keys/AuthKey_${{ secrets.APP_STORE_CONNECT_KEY_ID }}.p8 \
+          -authenticationKeyID ${{ secrets.APP_STORE_CONNECT_KEY_ID }} \
+          -authenticationKeyIssuerID ${{ secrets.APP_STORE_CONNECT_ISSUER_ID }}
+
+    - name: Upload IPA artifact
+      if: github.event_name != 'pull_request'
+      uses: actions/upload-artifact@v4
+      with:
+        name: ipa-${{ steps.version.outputs.version }}-${{ steps.version.outputs.build }}
+        path: |
+          ${{ runner.temp }}/Export/*.ipa
+          ${{ runner.temp }}/Export/App.xcarchive/dSYMs
+        retention-days: 30
+
+    - name: Summary
+      run: |
+        echo "## Build Successful" >> $GITHUB_STEP_SUMMARY
+        echo "- **Scheme**: SnowTracker" >> $GITHUB_STEP_SUMMARY
+        echo "- **Bundle ID**: com.wouterdevriendt.snowtracker" >> $GITHUB_STEP_SUMMARY
+        echo "- **Version**: ${{ steps.version.outputs.version }} (${{ steps.version.outputs.build }})" >> $GITHUB_STEP_SUMMARY
+        echo "- **Commit**: ${{ github.sha }}" >> $GITHUB_STEP_SUMMARY
+        if [ "${{ github.event_name }}" != "pull_request" ]; then
+          echo "- **Artifact**: ipa-${{ steps.version.outputs.version }}-${{ steps.version.outputs.build }}" >> $GITHUB_STEP_SUMMARY
+        fi
+        echo "" >> $GITHUB_STEP_SUMMARY
+        echo "### Next Steps" >> $GITHUB_STEP_SUMMARY
+        echo "Run **TestFlight Internal** workflow to upload to TestFlight." >> $GITHUB_STEP_SUMMARY
+
+    - name: Cleanup
+      if: always()
+      run: |
+        rm -rf $RUNNER_TEMP/private_keys $RUNNER_TEMP/Export

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,6 +54,19 @@ claude -p --dangerously-skip-permissions "Fix the failing tests in SnowTrackerTe
 
 A clean codebase is everyone's responsibility. Leave things better than you found them.
 
+### iOS Code Signing - NEVER Create New Certificates
+**CRITICAL**: The iOS build workflow uses App Store Connect API authentication for automatic
+code signing. This reuses existing certificates on the Apple Developer account. **NEVER**:
+- Set `skip_automatic_signing: false` in the shared ios-infra workflow (this creates new certs)
+- Install distribution certificates into a keychain during CI (causes cert conflicts)
+- Use any approach that creates new Apple Developer certificates on each build
+
+The correct approach (used in `ios-build.yml`, matching the footprint repo):
+- Use `-allowProvisioningUpdates` with ASC API auth (`-authenticationKeyPath`, `-authenticationKeyID`, `-authenticationKeyIssuerID`)
+- Set `CODE_SIGN_STYLE=Automatic` with `DEVELOPMENT_TEAM`
+- Do NOT install certificates manually - let Xcode resolve them via ASC API
+- For PRs: build with `CODE_SIGNING_ALLOWED=NO` (no signing needed)
+
 ### Always Test on Real Device
 When working on iOS changes, **always build and deploy to the physical device** if it's available. Don't just build for simulator - real device testing catches issues that simulators miss. After deploying, launch the app to verify the fix works.
 


### PR DESCRIPTION
## Summary
- Rewrites `ios-build.yml` to use inline build steps (matching the footprint repo approach)
- Uses App Store Connect API authentication for automatic code signing instead of the shared ios-infra workflow
- Stops creating new Apple Developer certificates on every build (was hitting Apple's max cert limit)
- Updates CLAUDE.md with code signing guidelines to prevent recurrence

## Root cause
The shared `ios-infra` workflow with `skip_automatic_signing: false` was installing a distribution certificate into a keychain AND using automatic signing, causing Xcode to create a new certificate on every build. Apple limits certs to 2, so builds fail once the limit is reached.

## Fix
Mirror footprint's approach: use `-allowProvisioningUpdates` with ASC API auth (`-authenticationKeyPath`, `-authenticationKeyID`, `-authenticationKeyIssuerID`) + `CODE_SIGN_STYLE=Automatic`. No manual cert installation. Xcode resolves existing certs via the ASC API.

## Test plan
- [ ] Verify PR build succeeds (no signing, `CODE_SIGNING_ALLOWED=NO`)
- [ ] Verify main push build archives and produces IPA artifact
- [ ] Verify TestFlight Internal workflow can download and upload the IPA
- [ ] Confirm no new certificates created in Apple Developer portal

🤖 Generated with [Claude Code](https://claude.com/claude-code)