### PR TITLE
Fix timeline quality, cache invalidation, and admin API selector

### DIFF
--- a/infrastructure/__main__.py
+++ b/infrastructure/__main__.py
@@ -463,6 +463,7 @@ weather_schedule_rule = aws.cloudwatch.EventRule(
     name=f"{app_name}-weather-schedule-{environment}",
     description="Trigger weather data fetch every hour",
     schedule_expression="rate(1 hour)",
+    is_enabled=True,
     tags=tags,
 )
 

--- a/ios/SnowTracker/SnowTracker/Sources/Services/CacheService.swift
+++ b/ios/SnowTracker/SnowTracker/Sources/Services/CacheService.swift
@@ -361,6 +361,23 @@ class CacheService {
         try? context.save()
     }
 
+    // MARK: - API Change Detection
+
+    private let lastAPIURLKey = "com.snowtracker.lastAPIBaseURL"
+
+    /// Check if the API URL has changed since the last session and invalidate
+    /// all cached data if so. This prevents stale data from a different
+    /// environment (e.g. staging) from being shown after switching to production.
+    func checkAndInvalidateIfAPIChanged() {
+        let currentURL = AppConfiguration.shared.apiBaseURL.absoluteString
+        let lastURL = UserDefaults.standard.string(forKey: lastAPIURLKey)
+        if let lastURL, lastURL != currentURL {
+            print("CacheService: API URL changed from \(lastURL) to \(currentURL) — clearing all cache")
+            clearAllCache()
+        }
+        UserDefaults.standard.set(currentURL, forKey: lastAPIURLKey)
+    }
+
     func clearAllCache() {
         guard let context = modelContext else { return }
 

--- a/ios/SnowTracker/SnowTracker/Sources/ViewModels/Managers.swift
+++ b/ios/SnowTracker/SnowTracker/Sources/ViewModels/Managers.swift
@@ -34,6 +34,10 @@ class SnowConditionsManager: ObservableObject {
         }
         hasLoadedInitialData = true
 
+        // 0. Check if API URL changed (e.g. switched from staging to prod)
+        //    and invalidate stale cache from the old environment
+        cacheService.checkAndInvalidateIfAPIChanged()
+
         // 1. Load cached data immediately so the UI is populated right away
         loadCachedDataSynchronously()
 


### PR DESCRIPTION
## Summary
- **Timeline snow quality**: Use global `_process_snowfall()` for cumulative freeze-thaw context instead of per-point isolation. Fixes timeline showing "icy"/"soft" for resorts that are "excellent". Also fixes snowfall rounding (2dp → 1dp to avoid "0cm" for 0.2cm).
- **Cache invalidation**: Clear all cached data when API URL changes (fixes stale staging cache showing "no data" in list/map views after switching to production).
- **Admin API selector**: Show environment picker (staging/prod) in Settings for admin users in release/TestFlight builds. Uses SHA256 email hash — no plaintext email in source.
- **Staging weather processor**: Explicitly set `is_enabled=True` on EventBridge rule so Pulumi drift-corrects the DISABLED state on next staging deploy.

## Files Changed
| File | Change |
|------|--------|
| `backend/src/services/openmeteo_service.py` | Global freeze-thaw context for timeline; snowfall rounding fix |
| `infrastructure/__main__.py` | `is_enabled=True` on weather schedule rule |
| `ios/.../CacheService.swift` | `checkAndInvalidateIfAPIChanged()` method |
| `ios/.../Managers.swift` | Call cache invalidation in `loadInitialData()` |
| `ios/.../Configuration.swift` | `showDeveloperSettings`, admin hash check, CryptoKit |
| `ios/.../SettingsView.swift` | Runtime `showDeveloperSettings` check instead of `#if DEBUG` |

## Test plan
- [x] Backend: 335 tests pass
- [x] iOS: Build succeeds, all unit tests pass
- [ ] Verify timeline quality matches resort overall quality after deploy
- [ ] Verify list/map views show data on fresh install
- [ ] Verify admin user sees env picker in TestFlight
- [ ] Verify staging weather processor runs after Pulumi deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)