### PR TITLE
Add retry button to resort detail no-data state

### DIFF
--- a/ios/SnowTracker/SnowTracker/Sources/Views/ResortDetailView.swift
+++ b/ios/SnowTracker/SnowTracker/Sources/Views/ResortDetailView.swift
@@ -634,10 +634,19 @@ struct ResortDetailView: View {
             Text("No Data Available")
                 .font(.headline)
 
-            Text("Weather conditions for this elevation are not currently available. Pull to refresh.")
+            Text("Weather conditions for this elevation are not currently available.")
                 .font(.body)
                 .foregroundStyle(.secondary)
                 .multilineTextAlignment(.center)
+
+            Button {
+                Task {
+                    await snowConditionsManager.refreshData()
+                }
+            } label: {
+                Label("Retry", systemImage: "arrow.clockwise")
+            }
+            .buttonStyle(.borderedProminent)
         }
         .frame(maxWidth: .infinity)
         .cardStyle()


### PR DESCRIPTION
## Summary
- Replace "Pull to refresh" text with explicit Retry button when weather conditions aren't available for the selected elevation
- More discoverable than requiring users to know about pull-to-refresh gesture

## Test plan
- [x] iOS builds successfully
- [x] All 106 iOS tests pass
- [x] Retry button triggers data refresh

🤖 Generated with [Claude Code](https://claude.com/claude-code)