### PR TITLE
Fix conditions endpoint, batch resort_count, and timeline snow depth

### DIFF
--- a/backend/src/handlers/api_handler.py
+++ b/backend/src/handlers/api_handler.py
@@ -767,7 +767,7 @@ async def get_batch_conditions(
         return {
             "results": results,
             "last_updated": datetime.now(UTC).isoformat(),
-            "resort_count": len(ids),
+            "resort_count": len(results),
         }
 
     except HTTPException:
@@ -1204,7 +1204,7 @@ async def get_batch_snow_quality(
             return {
                 "results": results,
                 "last_updated": datetime.now(UTC).isoformat(),
-                "resort_count": len(ids),
+                "resort_count": len(results),
                 "source": "static",
             }
 
@@ -1233,7 +1233,7 @@ async def get_batch_snow_quality(
         return {
             "results": results,
             "last_updated": datetime.now(UTC).isoformat(),
-            "resort_count": len(ids),
+            "resort_count": len(results),
             "source": "dynamodb",
         }
 


### PR DESCRIPTION
## Summary
- **Conditions endpoint** was returning ~50 entries (all historical data) instead of latest per elevation. Now correctly deduplicates by elevation level and filters by time range using the `hours_back` parameter (which was previously accepted but ignored).
- **Batch endpoints** (`/snow-quality/batch`, `/conditions/batch`) reported `resort_count` as the number of *requested* IDs, not the number of *returned* results. Fixed to report actual count.
- **Timeline snow depth** could show physically impossible drops (e.g., 165cm to 50cm in 4 hours) due to Open-Meteo forecast model splicing. Added post-processing smoothing that caps depth drops at 10cm/hour.

## Test plan
- [x] 15 new tests (6 conditions dedup + 9 timeline smoothing)
- [x] All 646 backend tests pass
- [ ] Verify conditions endpoint returns 3 entries (one per elevation) in production
- [ ] Verify batch resort_count matches actual results count
- [ ] Verify timeline snow depth has no impossible drops

🤖 Generated with [Claude Code](https://claude.com/claude-code)