### PR TITLE
Fix skeleton loader units to respect user preferences

### DIFF
--- a/ios/SnowTracker/SnowTracker/Sources/Views/ResortListView.swift
+++ b/ios/SnowTracker/SnowTracker/Sources/Views/ResortListView.swift
@@ -435,13 +435,15 @@ struct ResortRowView: View {
             } else {
                 // Loading skeleton while weather data is being fetched
                 HStack {
-                    Label("--\u{00B0}C", systemImage: "thermometer")
+                    let tempUnit = userPreferencesManager.preferredUnits.temperature == .celsius ? "C" : "F"
+                    Label("--\u{00B0}\(tempUnit)", systemImage: "thermometer")
                         .font(.caption)
                         .foregroundStyle(.secondary)
 
                     Spacer()
 
-                    Label("-- cm", systemImage: "snowflake")
+                    let snowUnit = userPreferencesManager.preferredUnits.snowDepth == .centimeters ? "cm" : "\""
+                    Label("-- \(snowUnit)", systemImage: "snowflake")
                         .font(.caption)
                         .foregroundStyle(.blue)
 


### PR DESCRIPTION
## Summary
- Loading skeleton in `ResortListView` now shows correct temperature unit (°C/°F) and snow depth unit (cm/") based on user preferences
- Previously hardcoded as "°C" and "cm" regardless of settings

## Test plan
- [x] iOS builds successfully
- [x] All 106 iOS tests pass
- [ ] Visual verification: set units to imperial, scroll through resort list

🤖 Generated with [Claude Code](https://claude.com/claude-code)