### PR TITLE
Fix hardcoded units in timeline and recommendations views

### DIFF
--- a/ios/SnowTracker/SnowTracker/Sources/Views/RecommendationsView.swift
+++ b/ios/SnowTracker/SnowTracker/Sources/Views/RecommendationsView.swift
@@ -115,10 +115,12 @@ struct BestSnowNearYouView: View {
                 ToolbarItem(placement: .topBarTrailing) {
                     Menu {
                         Section("Search Radius") {
-                            Button("250 km / 155 mi") { searchRadius = 250; Task { await refreshNearby() } }
-                            Button("500 km / 310 mi") { searchRadius = 500; Task { await refreshNearby() } }
-                            Button("750 km / 465 mi") { searchRadius = 750; Task { await refreshNearby() } }
-                            Button("1000 km / 620 mi (Recommended)") { searchRadius = 1000; Task { await refreshNearby() } }
+                            ForEach([250.0, 500.0, 750.0, 1000.0], id: \.self) { radius in
+                                let label = useMetric
+                                    ? "\(Int(radius)) km\(radius == 1000 ? " (Recommended)" : "")"
+                                    : "\(Int(radius * 0.621371)) mi\(radius == 1000 ? " (Recommended)" : "")"
+                                Button(label) { searchRadius = radius; Task { await refreshNearby() } }
+                            }
                         }
                     } label: {
                         Image(systemName: "slider.horizontal.3")
@@ -242,7 +244,7 @@ struct BestSnowNearYouView: View {
             if let error = recommendationsManager.errorMessage {
                 Text(error)
             } else {
-                Text("No resorts found within \(Int(searchRadius)) km. Try increasing the search radius.")
+                Text("No resorts found within \(useMetric ? "\(Int(searchRadius)) km" : "\(Int(searchRadius * 0.621371)) mi"). Try increasing the search radius.")
             }
         } actions: {
             Button("Refresh") {

--- a/ios/SnowTracker/SnowTracker/Sources/Views/TimelineView.swift
+++ b/ios/SnowTracker/SnowTracker/Sources/Views/TimelineView.swift
@@ -209,8 +209,13 @@ struct TimelinePointCard: View {
                 HStack(spacing: 2) {
                     Image(systemName: "wind")
                         .font(.system(size: 9))
-                    Text("\(Int(wind))")
-                        .font(.caption2)
+                    if prefs.distance == .metric {
+                        Text("\(Int(wind))")
+                            .font(.caption2)
+                    } else {
+                        Text("\(Int(wind * 0.621371))")
+                            .font(.caption2)
+                    }
                 }
                 .foregroundStyle(.secondary)
             }


### PR DESCRIPTION
## Summary
- **TimelineView**: Wind speed display now respects distance unit preference (km/h vs mph)
- **RecommendationsView**: Search radius buttons show appropriate unit (km or mi) instead of both
- **RecommendationsView**: Empty state "no resorts found" message uses correct distance unit

## Test plan
- [x] iOS builds successfully
- [x] All iOS tests pass
- [ ] Verify timeline wind shows correct unit with imperial settings
- [ ] Verify search radius menu shows km or mi based on preference

🤖 Generated with [Claude Code](https://claude.com/claude-code)