### PR TITLE
Lower timeline snow depth smoothing rate from 10cm/h to 2cm/h

### DIFF
--- a/backend/src/services/openmeteo_service.py
+++ b/backend/src/services/openmeteo_service.py
@@ -77,8 +77,10 @@ def _request_with_retry(
 
 
 # Max snow depth drop per hour (cm) considered physically realistic.
-# Even extreme conditions rarely exceed 5cm/hour melt rate.
-_MAX_DEPTH_DROP_PER_HOUR = 10.0
+# Real-world max snowmelt is ~5-10cm/day even in extreme warm/rain-on-snow
+# conditions. 2cm/hour is generous but catches Open-Meteo model splice artifacts
+# (e.g., ERA5→GFS transitions causing 100+ cm phantom drops in hours).
+_MAX_DEPTH_DROP_PER_HOUR = 2.0
 
 
 def _smooth_timeline_snow_depth(points: list[dict]) -> None:


### PR DESCRIPTION
## Summary
- Lowers `_MAX_DEPTH_DROP_PER_HOUR` from 10.0 to 2.0 in timeline smoothing
- The previous rate was too permissive: drops of 50cm/5h and 40cm/4h (exactly 10cm/h) from Open-Meteo model splices passed through unsmoothed
- Real-world max snowmelt is ~5-10cm/**day** even in extreme warm/rain-on-snow conditions, so 2cm/h is still generous
- Adds regression test for the exact Jackson Hole production scenario (192→142→102→17cm)

## Test plan
- [x] All 686 backend tests pass (including 10 smoothing tests)
- [x] Regression test covers the exact production data pattern
- [ ] Verify in production after deploy: Jackson Hole timeline has no >30cm drops

🤖 Generated with [Claude Code](https://claude.com/claude-code)