### PR TITLE
Remove unused non-prefs-aware formatting methods from WeatherCondition

### DIFF
--- a/ios/SnowTracker/SnowTracker/Sources/Models/WeatherCondition.swift
+++ b/ios/SnowTracker/SnowTracker/Sources/Models/WeatherCondition.swift
@@ -385,15 +385,6 @@ struct WeatherCondition: Codable, Identifiable, Hashable, Sendable {
         snowfallAfterFreezeCm ?? freshSnowCm
     }
 
-    /// Formatted fresh snow since freeze in inches
-    var formattedSnowSinceFreezeInches: String {
-        let inches = snowSinceFreeze / 2.54
-        if inches < 0.1 {
-            return "No fresh snow"
-        }
-        return String(format: "%.1f\" fresh", inches)
-    }
-
     /// Hours since last thaw-freeze event
     var formattedTimeSinceFreeze: String {
         guard let hours = lastFreezeThawHoursAgo else {
@@ -470,21 +461,6 @@ struct WeatherCondition: Codable, Identifiable, Hashable, Sendable {
         }
 
         return .icy
-    }
-
-    /// Formatted snow since freeze in cm
-    var formattedSnowSinceFreezeCm: String {
-        let cm = snowSinceFreeze
-        if cm < 0.1 {
-            return "0 cm"
-        }
-        return String(format: "%.1f cm", cm)
-    }
-
-    var formattedWindSpeed: String {
-        guard let windSpeed = windSpeedKmh else { return "No wind data" }
-        let windSpeedMph = windSpeed * 0.621371
-        return "\(Int(windSpeed))km/h (\(Int(windSpeedMph))mph)"
     }
 
     var formattedHumidity: String {

--- a/ios/SnowTracker/SnowTrackerTests/SnowTrackerTests.swift
+++ b/ios/SnowTracker/SnowTrackerTests/SnowTrackerTests.swift
@@ -226,8 +226,10 @@ final class SnowTrackerTests: XCTestCase {
     func testWeatherConditionWindSpeed() {
         let condition = WeatherCondition.sampleConditions.first { $0.windSpeedKmh != nil }
         XCTAssertNotNil(condition)
-        XCTAssertTrue(condition?.formattedWindSpeed.contains("km/h") ?? false)
-        XCTAssertTrue(condition?.formattedWindSpeed.contains("mph") ?? false)
+        let prefs = UnitPreferences(temperature: .celsius, distance: .metric, snowDepth: .centimeters)
+        XCTAssertTrue(condition?.formattedWindSpeedWithPrefs(prefs).contains("km/h") ?? false)
+        let imperialPrefs = UnitPreferences(temperature: .fahrenheit, distance: .imperial, snowDepth: .inches)
+        XCTAssertTrue(condition?.formattedWindSpeedWithPrefs(imperialPrefs).contains("mph") ?? false)
     }
 
     func testWeatherConditionHumidity() {
@@ -268,7 +270,8 @@ final class SnowTrackerTests: XCTestCase {
             sourceConfidence: .high,
             rawData: nil
         )
-        XCTAssertEqual(condition.formattedWindSpeed, "No wind data")
+        let windPrefs = UnitPreferences(temperature: .celsius, distance: .metric, snowDepth: .centimeters)
+        XCTAssertEqual(condition.formattedWindSpeedWithPrefs(windPrefs), "No wind data")
         XCTAssertEqual(condition.formattedHumidity, "No humidity data")
     }
 


### PR DESCRIPTION
## Summary
- Removes 3 dead code methods from `WeatherCondition.swift`:
  - `formattedWindSpeed` (superseded by `formattedWindSpeedWithPrefs`)
  - `formattedSnowSinceFreezeCm` (superseded by `formattedSnowSinceFreezeWithPrefs`)
  - `formattedSnowSinceFreezeInches` (superseded by `formattedSnowSinceFreezeWithPrefs`)
- Updates test assertions to use the unit-aware `WithPrefs` methods instead

## Test plan
- [x] iOS builds successfully
- [x] All 106 iOS tests pass with 0 failures
- [x] Grep confirms no remaining references to removed methods

🤖 Generated with [Claude Code](https://claude.com/claude-code)