### PR TITLE
Add 213 tests for scraper_worker, version_consolidator, and weather_worker

### DIFF
--- a/backend/tests/test_scraper_worker.py
+++ b/backend/tests/test_scraper_worker.py
@@ -1,0 +1,1593 @@
+"""Comprehensive unit tests for the scraper_worker Lambda handler.
+
+Tests cover:
+- ScraperSession (rate limiting, retries, get_soup)
+- get_region() mapping logic
+- collect_resort_urls() pagination and URL filtering
+- scrape_resort_detail() HTML parsing and data extraction
+- extract_state_province()
+- extract_coordinates()
+- geocode_resort()
+- generate_resort_id() (special characters, accents, etc.)
+- get_existing_resort_ids() DynamoDB scanning with pagination
+- publish_new_resorts_notification() SNS publishing
+- scraper_worker_handler() Lambda entry point (S3 uploads, delta mode, errors)
+"""
+
+import json
+import time
+from datetime import UTC, datetime
+from unittest.mock import MagicMock, Mock, call, patch
+
+import pytest
+import requests
+from bs4 import BeautifulSoup
+
+# We need to patch the module-level AWS clients before import.
+# The module initializes boto3 clients at import time, so we patch boto3.resource/client
+# during the import.
+with patch("boto3.resource"), patch("boto3.client"):
+    from handlers.scraper_worker import (
+        CA_PROVINCE_REGIONS,
+        COUNTRY_URLS,
+        MAX_RETRIES,
+        MIN_VERTICAL,
+        REGION_MAPPINGS,
+        US_STATE_REGIONS,
+        ScraperSession,
+        collect_resort_urls,
+        extract_coordinates,
+        extract_state_province,
+        generate_resort_id,
+        geocode_resort,
+        get_existing_resort_ids,
+        get_region,
+        publish_new_resorts_notification,
+        scrape_resort_detail,
+        scraper_worker_handler,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_soup(html: str) -> BeautifulSoup:
+    """Create a BeautifulSoup object from an HTML fragment."""
+    return BeautifulSoup(html, "html.parser")
+
+
+def _resort_page_html(
+    name="Chamonix Mont-Blanc",
+    base=1035,
+    top=3842,
+    data_lat=None,
+    data_lng=None,
+    script_coords=False,
+    mobile_header_text="",
+    has_next_page=False,
+):
+    """Build a minimal resort detail HTML page."""
+    coords_attr = ""
+    if data_lat is not None and data_lng is not None:
+        coords_attr = f'<div data-lat="{data_lat}" data-lng="{data_lng}"></div>'
+
+    script_tag = ""
+    if script_coords:
+        script_tag = "<script>var lat = 45.92; var lng = 6.87;</script>"
+
+    mobile = ""
+    if mobile_header_text:
+        mobile = f'<div class="mobile-header-regionselector">{mobile_header_text}</div>'
+
+    next_link = ""
+    if has_next_page:
+        next_link = (
+            '<div class="pagination"><a class="next" href="/page/2">Next</a></div>'
+        )
+
+    return f"""
+    <html><body>
+    <h1>Ski resort {name}</h1>
+    {mobile}
+    {coords_attr}
+    {script_tag}
+    <div>{base} m - {top} m</div>
+    {next_link}
+    </body></html>
+    """
+
+
+def _listing_page_html(resort_hrefs, has_next=False):
+    """Build a listing page with resort links."""
+    links = "\n".join(f'<a href="{href}">Resort</a>' for href in resort_hrefs)
+    pagination = ""
+    if has_next:
+        pagination = '<div class="pagination"><a class="next" href="#">Next</a></div>'
+    return f"<html><body>{links}{pagination}</body></html>"
+
+
+# ===========================================================================
+# Tests for generate_resort_id
+# ===========================================================================
+
+
+class TestGenerateResortId:
+    """Tests for the generate_resort_id helper."""
+
+    def test_basic_name(self):
+        assert generate_resort_id("Vail Mountain") == "vail-mountain"
+
+    def test_special_characters(self):
+        assert generate_resort_id("Val d'Isere") == "val-disere"
+
+    def test_accented_characters(self):
+        assert generate_resort_id("Kitzbuhel") == "kitzbuhel"
+        assert generate_resort_id("Chamonix Mont-Blanc") == "chamonix-mont-blanc"
+
+    def test_umlaut_o(self):
+        assert generate_resort_id("Soelden") == "soelden"
+        # o with umlaut
+        assert generate_resort_id("Solden") == "solden"
+
+    def test_accented_a(self):
+        assert generate_resort_id("Arlberg") == "arlberg"
+        # a with accent
+        result = generate_resort_id("Arare")
+        assert result == "arare"
+
+    def test_accented_e(self):
+        result = generate_resort_id("Val d'Isere")
+        assert "isere" in result
+
+    def test_accented_u(self):
+        result = generate_resort_id("Kitzbuhel")
+        assert result == "kitzbuhel"
+
+    def test_leading_trailing_hyphens_stripped(self):
+        result = generate_resort_id("  --Test Resort-- ")
+        assert not result.startswith("-")
+        assert not result.endswith("-")
+
+    def test_consecutive_hyphens_collapsed(self):
+        result = generate_resort_id("Big   White")
+        assert "--" not in result
+        assert result == "big-white"
+
+    def test_backtick_removed(self):
+        result = generate_resort_id("Val d`Isere")
+        assert "`" not in result
+
+    def test_empty_after_cleaning(self):
+        # Pure special characters produce an empty string
+        result = generate_resort_id("---")
+        assert result == ""
+
+    def test_numeric_names(self):
+        result = generate_resort_id("3 Valleys")
+        assert result == "3-valleys"
+
+
+# ===========================================================================
+# Tests for get_region
+# ===========================================================================
+
+
+class TestGetRegion:
+    """Tests for the get_region() function."""
+
+    def test_us_state_colorado(self):
+        assert get_region("US", "CO") == "na_rockies"
+
+    def test_us_state_california(self):
+        assert get_region("US", "CA") == "na_west"
+
+    def test_us_state_vermont(self):
+        assert get_region("US", "VT") == "na_east"
+
+    def test_us_state_wisconsin(self):
+        assert get_region("US", "WI") == "na_midwest"
+
+    def test_us_unknown_state_falls_through_to_country(self):
+        # US with unknown state falls back to REGION_MAPPINGS["US"]
+        assert get_region("US", "ZZ") == "na_rockies"
+
+    def test_canada_bc(self):
+        assert get_region("CA", "BC") == "na_west"
+
+    def test_canada_ab(self):
+        assert get_region("CA", "AB") == "na_rockies"
+
+    def test_canada_unknown_province(self):
+        assert get_region("CA", "ZZ") == "na_west"
+
+    def test_france_alps(self):
+        assert get_region("FR", "") == "alps"
+
+    def test_japan(self):
+        assert get_region("JP", "") == "japan"
+
+    def test_unknown_country(self):
+        assert get_region("XX", "") == "other"
+
+    def test_south_america(self):
+        assert get_region("CL", "") == "south_america"
+        assert get_region("AR", "") == "south_america"
+
+    def test_scandinavia(self):
+        assert get_region("NO", "") == "scandinavia"
+        assert get_region("SE", "") == "scandinavia"
+        assert get_region("FI", "") == "scandinavia"
+
+
+# ===========================================================================
+# Tests for ScraperSession
+# ===========================================================================
+
+
+class TestScraperSession:
+    """Tests for the ScraperSession HTTP wrapper."""
+
+    @patch("handlers.scraper_worker.time.sleep")
+    @patch("handlers.scraper_worker.time.time")
+    def test_rate_limiting_sleeps_when_too_fast(self, mock_time, mock_sleep):
+        """Requests closer than REQUEST_DELAY apart should trigger sleep."""
+        # First call to time.time() in __init__ is 0
+        # _rate_limit calls time.time() to get elapsed, then again to update _last_request_time
+        mock_time.side_effect = [100.0, 100.5, 101.0]
+        session = ScraperSession()
+        session._last_request_time = 100.0
+
+        mock_response = Mock()
+        mock_response.raise_for_status = Mock()
+        session.session = Mock()
+        session.session.get.return_value = mock_response
+
+        session.get("https://example.com")
+        mock_sleep.assert_called_once()
+
+    @patch("handlers.scraper_worker.time.sleep")
+    @patch("handlers.scraper_worker.time.time")
+    def test_no_sleep_when_enough_time_elapsed(self, mock_time, mock_sleep):
+        """No sleep needed when enough time has passed since last request."""
+        mock_time.side_effect = [200.0, 200.0]
+        session = ScraperSession()
+        session._last_request_time = 0  # Very old timestamp -> elapsed > REQUEST_DELAY
+
+        mock_response = Mock()
+        mock_response.raise_for_status = Mock()
+        session.session = Mock()
+        session.session.get.return_value = mock_response
+
+        session.get("https://example.com")
+        mock_sleep.assert_not_called()
+
+    @patch("handlers.scraper_worker.time.sleep")
+    @patch("handlers.scraper_worker.time.time")
+    def test_retries_on_request_exception(self, mock_time, mock_sleep):
+        """Should retry on RequestException up to MAX_RETRIES."""
+        mock_time.return_value = 0
+        session = ScraperSession()
+        session._last_request_time = 0
+
+        session.session = Mock()
+        session.session.get.side_effect = requests.RequestException("Connection error")
+
+        with pytest.raises(requests.RequestException):
+            session.get("https://example.com")
+
+        assert session.session.get.call_count == MAX_RETRIES
+
+    @patch("handlers.scraper_worker.time.sleep")
+    @patch("handlers.scraper_worker.time.time")
+    def test_successful_after_retry(self, mock_time, mock_sleep):
+        """Should succeed if a retry succeeds."""
+        mock_time.return_value = 0
+        session = ScraperSession()
+        session._last_request_time = 0
+
+        mock_response = Mock()
+        mock_response.raise_for_status = Mock()
+
+        session.session = Mock()
+        session.session.get.side_effect = [
+            requests.RequestException("Fail 1"),
+            mock_response,
+        ]
+
+        result = session.get("https://example.com")
+        assert result is mock_response
+        assert session.session.get.call_count == 2
+
+    @patch("handlers.scraper_worker.time.sleep")
+    @patch("handlers.scraper_worker.time.time")
+    def test_get_soup_returns_beautifulsoup(self, mock_time, mock_sleep):
+        """get_soup should return a BeautifulSoup object."""
+        mock_time.return_value = 0
+        session = ScraperSession()
+        session._last_request_time = 0
+
+        mock_response = Mock()
+        mock_response.raise_for_status = Mock()
+        mock_response.text = "<html><body><h1>Hello</h1></body></html>"
+
+        session.session = Mock()
+        session.session.get.return_value = mock_response
+
+        soup = session.get_soup("https://example.com")
+        assert isinstance(soup, BeautifulSoup)
+        assert soup.h1.get_text() == "Hello"
+
+    @patch("handlers.scraper_worker.time.sleep")
+    @patch("handlers.scraper_worker.time.time")
+    def test_exponential_backoff_on_retries(self, mock_time, mock_sleep):
+        """Should use exponential backoff between retries."""
+        mock_time.return_value = 0
+        session = ScraperSession()
+        session._last_request_time = 0
+
+        session.session = Mock()
+        session.session.get.side_effect = requests.RequestException("Error")
+
+        with pytest.raises(requests.RequestException):
+            session.get("https://example.com")
+
+        # Check backoff sleep calls: 2^0=1, 2^1=2 (third attempt raises, no sleep after)
+        backoff_calls = [
+            c
+            for c in mock_sleep.call_args_list
+            if c != call(pytest.approx(1.0, abs=1.1))
+        ]
+        # The sleeps should include exponential backoff (2**0=1 and 2**1=2)
+        sleep_args = [c[0][0] for c in mock_sleep.call_args_list]
+        # At least some of these should be backoff values
+        assert 1 in sleep_args or 2 in sleep_args
+
+
+# ===========================================================================
+# Tests for extract_coordinates
+# ===========================================================================
+
+
+class TestExtractCoordinates:
+    """Tests for extracting coordinates from HTML."""
+
+    def test_data_attributes_lat_lng(self):
+        soup = _make_soup('<div data-lat="47.45" data-lng="12.39"></div>')
+        lat, lon = extract_coordinates(soup)
+        assert lat == 47.45
+        assert lon == 12.39
+
+    def test_data_attributes_latitude_longitude(self):
+        soup = _make_soup('<div data-latitude="45.0" data-longitude="6.9"></div>')
+        lat, lon = extract_coordinates(soup)
+        assert lat == 45.0
+        assert lon == 6.9
+
+    def test_data_attributes_lat_lon(self):
+        soup = _make_soup('<div data-lat="40.0" data-lon="-111.5"></div>')
+        lat, lon = extract_coordinates(soup)
+        assert lat == 40.0
+        assert lon == -111.5
+
+    def test_script_tag_coordinates(self):
+        # The regex expects lat[itude]*["':\s]+ then digits, so use JSON-like format
+        soup = _make_soup('<script>{"lat": 45.92, "lng": 6.87}</script>')
+        lat, lon = extract_coordinates(soup)
+        assert lat == pytest.approx(45.92)
+        assert lon == pytest.approx(6.87)
+
+    def test_script_tag_with_quotes(self):
+        soup = _make_soup(
+            """<script>{"latitude": "48.12", "longitude": "11.07"}</script>"""
+        )
+        lat, lon = extract_coordinates(soup)
+        assert lat == pytest.approx(48.12)
+        assert lon == pytest.approx(11.07)
+
+    def test_no_coordinates_returns_zeros(self):
+        soup = _make_soup("<html><body><p>No coordinates here</p></body></html>")
+        lat, lon = extract_coordinates(soup)
+        assert lat == 0.0
+        assert lon == 0.0
+
+    def test_negative_coordinates(self):
+        soup = _make_soup('<div data-lat="-43.5" data-lng="172.6"></div>')
+        lat, lon = extract_coordinates(soup)
+        assert lat == -43.5
+        assert lon == 172.6
+
+
+# ===========================================================================
+# Tests for extract_state_province
+# ===========================================================================
+
+
+class TestExtractStateProvince:
+    """Tests for extracting state/province information."""
+
+    def test_us_state_extraction(self):
+        html = '<div class="mobile-header-regionselector">WorldwideNorth AmericaUSAColoradoVail</div>'
+        soup = _make_soup(html)
+        result = extract_state_province(soup, "US")
+        assert result == "Colorado"
+
+    def test_canada_province_extraction(self):
+        html = '<div class="mobile-header-regionselector">WorldwideNorth AmericaCanadaBritish Columbia</div>'
+        soup = _make_soup(html)
+        result = extract_state_province(soup, "CA")
+        # The regex looks for CanadaXxx pattern
+        assert "British" in result or result != ""
+
+    def test_no_mobile_header_returns_empty(self):
+        soup = _make_soup("<html><body><p>Nothing here</p></body></html>")
+        result = extract_state_province(soup, "US")
+        assert result == ""
+
+    def test_non_us_non_ca_returns_empty(self):
+        html = '<div class="mobile-header-regionselector">SomeText</div>'
+        soup = _make_soup(html)
+        result = extract_state_province(soup, "FR")
+        assert result == ""
+
+    def test_worldwide_filtered_out(self):
+        html = '<div class="mobile-header-regionselector">USAWorldwide</div>'
+        soup = _make_soup(html)
+        result = extract_state_province(soup, "US")
+        # "Worldwide" should be filtered out
+        assert result != "Worldwide"
+
+
+# ===========================================================================
+# Tests for geocode_resort
+# ===========================================================================
+
+
+class TestGeocodeResort:
+    """Tests for the geocoding fallback."""
+
+    @patch("handlers.scraper_worker.requests.get")
+    def test_successful_geocode_matching_country(self, mock_get):
+        mock_response = Mock()
+        mock_response.raise_for_status = Mock()
+        mock_response.json.return_value = {
+            "results": [
+                {"latitude": 45.92, "longitude": 6.87, "country_code": "FR"},
+            ]
+        }
+        mock_get.return_value = mock_response
+
+        lat, lon = geocode_resort("Chamonix", "FR")
+        assert lat == 45.92
+        assert lon == 6.87
+
+    @patch("handlers.scraper_worker.requests.get")
+    def test_geocode_fallback_to_first_result(self, mock_get):
+        mock_response = Mock()
+        mock_response.raise_for_status = Mock()
+        mock_response.json.return_value = {
+            "results": [
+                {"latitude": 46.0, "longitude": 7.0, "country_code": "CH"},
+            ]
+        }
+        mock_get.return_value = mock_response
+
+        lat, lon = geocode_resort("Chamonix", "FR")
+        assert lat == 46.0
+        assert lon == 7.0
+
+    @patch("handlers.scraper_worker.requests.get")
+    def test_geocode_no_results_retries_without_ski(self, mock_get):
+        """When first search returns no results, retry without 'ski' suffix."""
+        mock_response_empty = Mock()
+        mock_response_empty.raise_for_status = Mock()
+        mock_response_empty.json.return_value = {"results": []}
+
+        mock_response_with_result = Mock()
+        mock_response_with_result.raise_for_status = Mock()
+        mock_response_with_result.json.return_value = {
+            "results": [
+                {"latitude": 39.64, "longitude": -106.37, "country_code": "US"},
+            ]
+        }
+
+        mock_get.side_effect = [mock_response_empty, mock_response_with_result]
+
+        lat, lon = geocode_resort("Vail", "US")
+        assert lat == 39.64
+        assert lon == -106.37
+        assert mock_get.call_count == 2
+
+    @patch("handlers.scraper_worker.requests.get")
+    def test_geocode_failure_returns_zeros(self, mock_get):
+        mock_get.side_effect = requests.RequestException("Timeout")
+
+        lat, lon = geocode_resort("Unknown Resort", "XX")
+        assert lat == 0.0
+        assert lon == 0.0
+
+    @patch("handlers.scraper_worker.requests.get")
+    def test_geocode_no_results_at_all(self, mock_get):
+        mock_response = Mock()
+        mock_response.raise_for_status = Mock()
+        mock_response.json.return_value = {}
+
+        mock_get.return_value = mock_response
+
+        lat, lon = geocode_resort("Nonexistent Resort", "XX")
+        assert lat == 0.0
+        assert lon == 0.0
+
+    @patch("handlers.scraper_worker.requests.get")
+    def test_geocode_cleans_name(self, mock_get):
+        """Verify name cleaning removes 'ski resort', 'ski area', 'mountain resort'."""
+        mock_response = Mock()
+        mock_response.raise_for_status = Mock()
+        mock_response.json.return_value = {
+            "results": [
+                {"latitude": 45.0, "longitude": 6.0, "country_code": "FR"},
+            ]
+        }
+        mock_get.return_value = mock_response
+
+        geocode_resort("Chamonix Ski Resort", "FR")
+
+        # Check that the cleaned name was sent -- "ski resort" removed
+        first_call_params = mock_get.call_args_list[0][1]["params"]
+        assert "ski resort" not in first_call_params["name"]
+        # The name should contain "chamonix" (lowered) with "ski" suffix appended
+        assert "chamonix" in first_call_params["name"]
+
+    @patch("handlers.scraper_worker.requests.get")
+    def test_geocode_skips_zero_coords_in_results(self, mock_get):
+        """Skip results where latitude and longitude are both 0.0."""
+        mock_response = Mock()
+        mock_response.raise_for_status = Mock()
+        mock_response.json.return_value = {
+            "results": [
+                {"latitude": 0.0, "longitude": 0.0, "country_code": "US"},
+                {"latitude": 40.0, "longitude": -105.0, "country_code": "US"},
+            ]
+        }
+        mock_get.return_value = mock_response
+
+        lat, lon = geocode_resort("Vail", "US")
+        # First result has 0,0 but lat!=0 OR lon!=0 fails, so falls through
+        # The code checks `if lat != 0.0 or lon != 0.0` -- 0.0 and 0.0 is False
+        # So it should skip the first result and return the second
+        assert lat == 40.0
+        assert lon == -105.0
+
+
+# ===========================================================================
+# Tests for collect_resort_urls
+# ===========================================================================
+
+
+class TestCollectResortUrls:
+    """Tests for collecting resort URLs from listing pages."""
+
+    @patch("handlers.scraper_worker.time.sleep")
+    @patch("handlers.scraper_worker.time.time", return_value=0)
+    def test_single_page_collection(self, mock_time, mock_sleep):
+        html = _listing_page_html(
+            [
+                "/ski-resort/chamonix-mont-blanc",
+                "/ski-resort/val-disere",
+            ]
+        )
+        session = ScraperSession()
+        session._last_request_time = 0
+
+        mock_response = Mock()
+        mock_response.raise_for_status = Mock()
+        mock_response.text = html
+        session.session = Mock()
+        session.session.get.return_value = mock_response
+
+        urls = collect_resort_urls(session, "FR")
+        assert len(urls) == 2
+        assert all(country == "FR" for _, country in urls)
+        assert any("chamonix" in url for url, _ in urls)
+
+    @patch("handlers.scraper_worker.time.sleep")
+    @patch("handlers.scraper_worker.time.time", return_value=0)
+    def test_skips_non_resort_links(self, mock_time, mock_sleep):
+        """Links like snow-report, reviews, etc. should be filtered."""
+        html = _listing_page_html(
+            [
+                "/ski-resort/chamonix-mont-blanc",
+                "/ski-resort/chamonix-mont-blanc/snow-report",
+                "/ski-resort/chamonix-mont-blanc/reviews",
+                "/ski-resort/chamonix-mont-blanc/webcams",
+                "/ski-resort/chamonix-mont-blanc/trail-map",
+                "/ski-resort/chamonix-mont-blanc/test-report",
+                "/ski-resort/chamonix-mont-blanc/photos",
+            ]
+        )
+        session = ScraperSession()
+        session._last_request_time = 0
+
+        mock_response = Mock()
+        mock_response.raise_for_status = Mock()
+        mock_response.text = html
+        session.session = Mock()
+        session.session.get.return_value = mock_response
+
+        urls = collect_resort_urls(session, "FR")
+        assert len(urls) == 1
+        assert "snow-report" not in urls[0][0]
+
+    @patch("handlers.scraper_worker.time.sleep")
+    @patch("handlers.scraper_worker.time.time", return_value=0)
+    def test_deduplicates_urls(self, mock_time, mock_sleep):
+        html = _listing_page_html(
+            [
+                "/ski-resort/chamonix",
+                "/ski-resort/chamonix",
+                "/ski-resort/chamonix",
+            ]
+        )
+        session = ScraperSession()
+        session._last_request_time = 0
+
+        mock_response = Mock()
+        mock_response.raise_for_status = Mock()
+        mock_response.text = html
+        session.session = Mock()
+        session.session.get.return_value = mock_response
+
+        urls = collect_resort_urls(session, "FR")
+        assert len(urls) == 1
+
+    @patch("handlers.scraper_worker.time.sleep")
+    @patch("handlers.scraper_worker.time.time", return_value=0)
+    def test_multi_page_pagination(self, mock_time, mock_sleep):
+        """Should follow pagination to collect URLs from multiple pages."""
+        page1_html = _listing_page_html(["/ski-resort/resort-a"], has_next=True)
+        page2_html = _listing_page_html(["/ski-resort/resort-b"], has_next=False)
+
+        session = ScraperSession()
+        session._last_request_time = 0
+
+        resp1 = Mock()
+        resp1.raise_for_status = Mock()
+        resp1.text = page1_html
+
+        resp2 = Mock()
+        resp2.raise_for_status = Mock()
+        resp2.text = page2_html
+
+        session.session = Mock()
+        session.session.get.side_effect = [resp1, resp2]
+
+        urls = collect_resort_urls(session, "FR")
+        assert len(urls) == 2
+
+    @patch("handlers.scraper_worker.time.sleep")
+    @patch("handlers.scraper_worker.time.time", return_value=0)
+    def test_stops_on_404(self, mock_time, mock_sleep):
+        """Should stop collecting when a 404 is encountered."""
+        session = ScraperSession()
+        session._last_request_time = 0
+
+        # First page works, second returns 404
+        resp1 = Mock()
+        resp1.raise_for_status = Mock()
+        resp1.text = _listing_page_html(["/ski-resort/resort-a"], has_next=True)
+
+        http_error = requests.HTTPError()
+        http_error.response = Mock()
+        http_error.response.status_code = 404
+
+        resp2 = Mock()
+        resp2.raise_for_status.side_effect = http_error
+        resp2.text = ""
+
+        session.session = Mock()
+        session.session.get.side_effect = [resp1, resp2]
+
+        # The get_soup method calls get which calls raise_for_status
+        # For 404, it should be caught in collect_resort_urls
+        # We need to make get_soup raise HTTPError for the second page
+        # Actually, let's patch at a higher level
+        original_get_soup = session.get_soup
+
+        call_count = [0]
+
+        def mock_get_soup(url, **kwargs):
+            call_count[0] += 1
+            if call_count[0] == 1:
+                return _make_soup(
+                    _listing_page_html(["/ski-resort/resort-a"], has_next=True)
+                )
+            else:
+                raise http_error
+
+        session.get_soup = mock_get_soup
+
+        urls = collect_resort_urls(session, "FR")
+        assert len(urls) == 1
+
+
+# ===========================================================================
+# Tests for scrape_resort_detail
+# ===========================================================================
+
+
+class TestScrapeResortDetail:
+    """Tests for scraping individual resort pages."""
+
+    @patch("handlers.scraper_worker.geocode_resort", return_value=(45.92, 6.87))
+    @patch("handlers.scraper_worker.time.sleep")
+    @patch("handlers.scraper_worker.time.time", return_value=0)
+    def test_successful_scrape(self, mock_time, mock_sleep, mock_geocode):
+        html = _resort_page_html(
+            name="Chamonix Mont-Blanc",
+            base=1035,
+            top=3842,
+            data_lat=45.92,
+            data_lng=6.87,
+        )
+        session = ScraperSession()
+        session._last_request_time = 0
+        mock_response = Mock()
+        mock_response.raise_for_status = Mock()
+        mock_response.text = html
+        session.session = Mock()
+        session.session.get.return_value = mock_response
+
+        result = scrape_resort_detail(
+            session,
+            "https://www.skiresort.info/ski-resort/chamonix",
+            "FR",
+        )
+
+        assert result is not None
+        assert result["name"] == "Chamonix Mont-Blanc"
+        assert result["elevation_base_m"] == 1035
+        assert result["elevation_top_m"] == 3842
+        assert result["country"] == "FR"
+        assert result["region"] == "alps"
+        assert result["latitude"] == 45.92
+        assert result["longitude"] == 6.87
+        assert result["resort_id"] == "chamonix-mont-blanc"
+        assert result["source"] == "skiresort.info"
+
+    @patch("handlers.scraper_worker.geocode_resort", return_value=(0.0, 0.0))
+    @patch("handlers.scraper_worker.time.sleep")
+    @patch("handlers.scraper_worker.time.time", return_value=0)
+    def test_returns_none_when_no_name(self, mock_time, mock_sleep, mock_geocode):
+        """Returns None when no h1 or name element is found."""
+        html = "<html><body><p>No name here</p><div>1000 m - 2000 m</div></body></html>"
+        session = ScraperSession()
+        session._last_request_time = 0
+        mock_response = Mock()
+        mock_response.raise_for_status = Mock()
+        mock_response.text = html
+        session.session = Mock()
+        session.session.get.return_value = mock_response
+
+        result = scrape_resort_detail(session, "https://example.com", "FR")
+        assert result is None
+
+    @patch("handlers.scraper_worker.geocode_resort", return_value=(0.0, 0.0))
+    @patch("handlers.scraper_worker.time.sleep")
+    @patch("handlers.scraper_worker.time.time", return_value=0)
+    def test_returns_none_when_no_elevation(self, mock_time, mock_sleep, mock_geocode):
+        """Returns None when elevation data is missing."""
+        html = "<html><body><h1>Test Resort</h1><p>No elevation</p></body></html>"
+        session = ScraperSession()
+        session._last_request_time = 0
+        mock_response = Mock()
+        mock_response.raise_for_status = Mock()
+        mock_response.text = html
+        session.session = Mock()
+        session.session.get.return_value = mock_response
+
+        result = scrape_resort_detail(session, "https://example.com", "FR")
+        assert result is None
+
+    @patch("handlers.scraper_worker.geocode_resort", return_value=(0.0, 0.0))
+    @patch("handlers.scraper_worker.time.sleep")
+    @patch("handlers.scraper_worker.time.time", return_value=0)
+    def test_returns_none_when_vertical_too_small(
+        self, mock_time, mock_sleep, mock_geocode
+    ):
+        """Returns None when vertical drop is below MIN_VERTICAL (300m)."""
+        html = _resort_page_html(name="Tiny Hill", base=1000, top=1100)
+        session = ScraperSession()
+        session._last_request_time = 0
+        mock_response = Mock()
+        mock_response.raise_for_status = Mock()
+        mock_response.text = html
+        session.session = Mock()
+        session.session.get.return_value = mock_response
+
+        result = scrape_resort_detail(session, "https://example.com", "FR")
+        assert result is None
+
+    @patch("handlers.scraper_worker.geocode_resort", return_value=(0.0, 0.0))
+    @patch("handlers.scraper_worker.time.sleep")
+    @patch("handlers.scraper_worker.time.time", return_value=0)
+    def test_skips_snow_report_pages(self, mock_time, mock_sleep, mock_geocode):
+        """Pages whose name starts with 'Snow report' should be skipped."""
+        html = "<html><body><h1>Snow report Chamonix</h1><div>1000 m - 3000 m</div></body></html>"
+        session = ScraperSession()
+        session._last_request_time = 0
+        mock_response = Mock()
+        mock_response.raise_for_status = Mock()
+        mock_response.text = html
+        session.session = Mock()
+        session.session.get.return_value = mock_response
+
+        result = scrape_resort_detail(session, "https://example.com", "FR")
+        assert result is None
+
+    @patch("handlers.scraper_worker.geocode_resort", return_value=(0.0, 0.0))
+    @patch("handlers.scraper_worker.time.sleep")
+    @patch("handlers.scraper_worker.time.time", return_value=0)
+    def test_cleans_ski_resort_prefix(self, mock_time, mock_sleep, mock_geocode):
+        """'Ski resort ' prefix should be stripped from names.
+
+        The _resort_page_html template already adds 'Ski resort ' to the h1,
+        so pass just the resort name to test the cleaning logic.
+        """
+        html = _resort_page_html(name="Chamonix", base=1000, top=3000)
+        session = ScraperSession()
+        session._last_request_time = 0
+        mock_response = Mock()
+        mock_response.raise_for_status = Mock()
+        mock_response.text = html
+        session.session = Mock()
+        session.session.get.return_value = mock_response
+
+        result = scrape_resort_detail(session, "https://example.com", "FR")
+        assert result is not None
+        # The h1 text is "Ski resort Chamonix"; the cleaning regex removes the prefix
+        assert result["name"] == "Chamonix"
+        assert not result["name"].lower().startswith("ski resort")
+
+    @patch("handlers.scraper_worker.time.sleep")
+    @patch("handlers.scraper_worker.time.time", return_value=0)
+    def test_returns_none_on_fetch_error(self, mock_time, mock_sleep):
+        """Returns None when the HTTP request fails."""
+        session = ScraperSession()
+        session._last_request_time = 0
+        session.session = Mock()
+        session.session.get.side_effect = requests.RequestException("Timeout")
+
+        result = scrape_resort_detail(session, "https://example.com", "FR")
+        assert result is None
+
+    @patch("handlers.scraper_worker.geocode_resort", return_value=(45.92, 6.87))
+    @patch("handlers.scraper_worker.time.sleep")
+    @patch("handlers.scraper_worker.time.time", return_value=0)
+    def test_elevation_base_top_swap_when_reversed(
+        self, mock_time, mock_sleep, mock_geocode
+    ):
+        """If base > top in the range pattern, they should be swapped."""
+        html = _resort_page_html(name="Test Resort", base=3000, top=1000)
+        session = ScraperSession()
+        session._last_request_time = 0
+        mock_response = Mock()
+        mock_response.raise_for_status = Mock()
+        mock_response.text = html
+        session.session = Mock()
+        session.session.get.return_value = mock_response
+
+        result = scrape_resort_detail(session, "https://example.com", "FR")
+        assert result is not None
+        assert result["elevation_base_m"] == 1000
+        assert result["elevation_top_m"] == 3000
+
+    @patch("handlers.scraper_worker.geocode_resort", return_value=(0.0, 0.0))
+    @patch("handlers.scraper_worker.time.sleep")
+    @patch("handlers.scraper_worker.time.time", return_value=0)
+    def test_geohash_is_none_when_no_coords(self, mock_time, mock_sleep, mock_geocode):
+        """geo_hash should be None when coordinates are (0,0)."""
+        html = _resort_page_html(name="Test Resort", base=1000, top=3000)
+        session = ScraperSession()
+        session._last_request_time = 0
+        mock_response = Mock()
+        mock_response.raise_for_status = Mock()
+        mock_response.text = html
+        session.session = Mock()
+        session.session.get.return_value = mock_response
+
+        result = scrape_resort_detail(session, "https://example.com", "FR")
+        assert result is not None
+        assert result["geo_hash"] is None
+
+    @patch("handlers.scraper_worker.encode_geohash", return_value="u0nd")
+    @patch("handlers.scraper_worker.geocode_resort", return_value=(47.0, 12.0))
+    @patch("handlers.scraper_worker.time.sleep")
+    @patch("handlers.scraper_worker.time.time", return_value=0)
+    def test_geohash_set_when_coords_available(
+        self, mock_time, mock_sleep, mock_geocode, mock_geohash
+    ):
+        """geo_hash should be computed when valid coordinates exist."""
+        html = _resort_page_html(
+            name="Test Resort", base=1000, top=3000, data_lat=47.0, data_lng=12.0
+        )
+        session = ScraperSession()
+        session._last_request_time = 0
+        mock_response = Mock()
+        mock_response.raise_for_status = Mock()
+        mock_response.text = html
+        session.session = Mock()
+        session.session.get.return_value = mock_response
+
+        result = scrape_resort_detail(session, "https://example.com", "AT")
+        assert result is not None
+        assert result["geo_hash"] == "u0nd"
+
+    @patch("handlers.scraper_worker.geocode_resort", return_value=(45.0, 6.0))
+    @patch("handlers.scraper_worker.time.sleep")
+    @patch("handlers.scraper_worker.time.time", return_value=0)
+    def test_scraped_at_is_iso_format(self, mock_time, mock_sleep, mock_geocode):
+        """scraped_at field should be a valid ISO format timestamp."""
+        html = _resort_page_html(
+            name="Test Resort", base=1000, top=3000, data_lat=45.0, data_lng=6.0
+        )
+        session = ScraperSession()
+        session._last_request_time = 0
+        mock_response = Mock()
+        mock_response.raise_for_status = Mock()
+        mock_response.text = html
+        session.session = Mock()
+        session.session.get.return_value = mock_response
+
+        result = scrape_resort_detail(session, "https://example.com", "FR")
+        assert result is not None
+        # Should be parseable as an ISO timestamp
+        datetime.fromisoformat(result["scraped_at"])
+
+
+# ===========================================================================
+# Tests for get_existing_resort_ids
+# ===========================================================================
+
+
+class TestGetExistingResortIds:
+    """Tests for DynamoDB scanning to get existing resort IDs."""
+
+    @patch("handlers.scraper_worker.dynamodb")
+    def test_returns_ids_from_single_scan(self, mock_dynamodb):
+        mock_table = Mock()
+        mock_table.scan.return_value = {
+            "Items": [
+                {"resort_id": "chamonix"},
+                {"resort_id": "zermatt"},
+            ]
+        }
+        mock_dynamodb.Table.return_value = mock_table
+
+        ids = get_existing_resort_ids()
+        assert ids == {"chamonix", "zermatt"}
+
+    @patch("handlers.scraper_worker.dynamodb")
+    def test_handles_paginated_scan(self, mock_dynamodb):
+        mock_table = Mock()
+        mock_table.scan.side_effect = [
+            {
+                "Items": [{"resort_id": "resort-a"}],
+                "LastEvaluatedKey": {"resort_id": "resort-a"},
+            },
+            {
+                "Items": [{"resort_id": "resort-b"}],
+            },
+        ]
+        mock_dynamodb.Table.return_value = mock_table
+
+        ids = get_existing_resort_ids()
+        assert ids == {"resort-a", "resort-b"}
+        assert mock_table.scan.call_count == 2
+
+    @patch("handlers.scraper_worker.dynamodb")
+    def test_returns_empty_set_on_error(self, mock_dynamodb):
+        mock_table = Mock()
+        mock_table.scan.side_effect = Exception("DynamoDB error")
+        mock_dynamodb.Table.return_value = mock_table
+
+        ids = get_existing_resort_ids()
+        assert ids == set()
+
+    @patch("handlers.scraper_worker.dynamodb")
+    def test_returns_empty_set_when_no_items(self, mock_dynamodb):
+        mock_table = Mock()
+        mock_table.scan.return_value = {"Items": []}
+        mock_dynamodb.Table.return_value = mock_table
+
+        ids = get_existing_resort_ids()
+        assert ids == set()
+
+
+# ===========================================================================
+# Tests for publish_new_resorts_notification
+# ===========================================================================
+
+
+class TestPublishNewResortsNotification:
+    """Tests for SNS notification publishing."""
+
+    @patch(
+        "handlers.scraper_worker.NEW_RESORTS_TOPIC_ARN",
+        "arn:aws:sns:us-west-2:123:topic",
+    )
+    @patch("handlers.scraper_worker.sns")
+    def test_publishes_notification_for_new_resorts(self, mock_sns):
+        resorts = [
+            {
+                "name": "New Resort",
+                "region": "alps",
+                "elevation_base_m": 1000,
+                "elevation_top_m": 3000,
+                "latitude": 45.0,
+                "longitude": 6.0,
+            }
+        ]
+        publish_new_resorts_notification(resorts, "FR", "job-123")
+
+        mock_sns.publish.assert_called_once()
+        call_kwargs = mock_sns.publish.call_args[1]
+        assert "arn:aws:sns" in call_kwargs["TopicArn"]
+        assert "1 new resorts" in call_kwargs["Subject"]
+        assert "FR" in call_kwargs["Subject"]
+
+    @patch("handlers.scraper_worker.NEW_RESORTS_TOPIC_ARN", "")
+    @patch("handlers.scraper_worker.sns")
+    def test_skips_when_no_topic_arn(self, mock_sns):
+        resorts = [{"name": "Test"}]
+        publish_new_resorts_notification(resorts, "FR", "job-123")
+        mock_sns.publish.assert_not_called()
+
+    @patch(
+        "handlers.scraper_worker.NEW_RESORTS_TOPIC_ARN",
+        "arn:aws:sns:us-west-2:123:topic",
+    )
+    @patch("handlers.scraper_worker.sns")
+    def test_skips_when_empty_resorts(self, mock_sns):
+        publish_new_resorts_notification([], "FR", "job-123")
+        mock_sns.publish.assert_not_called()
+
+    @patch(
+        "handlers.scraper_worker.NEW_RESORTS_TOPIC_ARN",
+        "arn:aws:sns:us-west-2:123:topic",
+    )
+    @patch("handlers.scraper_worker.sns")
+    def test_includes_missing_coords_warning(self, mock_sns):
+        resorts = [
+            {
+                "name": "No Coords Resort",
+                "region": "alps",
+                "elevation_base_m": 1000,
+                "elevation_top_m": 2000,
+                "latitude": 0.0,
+                "longitude": 0.0,
+            }
+        ]
+        publish_new_resorts_notification(resorts, "FR", "job-123")
+
+        call_kwargs = mock_sns.publish.call_args[1]
+        assert "missing coords" in call_kwargs["Subject"]
+        assert "WARNING" in call_kwargs["Message"]
+        assert "No Coords Resort" in call_kwargs["Message"]
+
+    @patch(
+        "handlers.scraper_worker.NEW_RESORTS_TOPIC_ARN",
+        "arn:aws:sns:us-west-2:123:topic",
+    )
+    @patch("handlers.scraper_worker.sns")
+    def test_truncates_long_resort_list(self, mock_sns):
+        """Should only show first 20 resorts in the message."""
+        resorts = [
+            {
+                "name": f"Resort {i}",
+                "region": "alps",
+                "elevation_base_m": 1000,
+                "elevation_top_m": 2000,
+                "latitude": 45.0,
+                "longitude": 6.0,
+            }
+            for i in range(25)
+        ]
+        publish_new_resorts_notification(resorts, "FR", "job-123")
+
+        call_kwargs = mock_sns.publish.call_args[1]
+        assert "and 5 more" in call_kwargs["Message"]
+
+    @patch(
+        "handlers.scraper_worker.NEW_RESORTS_TOPIC_ARN",
+        "arn:aws:sns:us-west-2:123:topic",
+    )
+    @patch("handlers.scraper_worker.sns")
+    def test_handles_sns_error_gracefully(self, mock_sns):
+        mock_sns.publish.side_effect = Exception("SNS error")
+        resorts = [
+            {
+                "name": "Test",
+                "region": "alps",
+                "elevation_base_m": 1000,
+                "elevation_top_m": 2000,
+                "latitude": 45.0,
+                "longitude": 6.0,
+            }
+        ]
+        # Should not raise
+        publish_new_resorts_notification(resorts, "FR", "job-123")
+
+    @patch(
+        "handlers.scraper_worker.NEW_RESORTS_TOPIC_ARN",
+        "arn:aws:sns:us-west-2:123:topic",
+    )
+    @patch("handlers.scraper_worker.sns")
+    def test_subject_truncated_to_100_chars(self, mock_sns):
+        resorts = [
+            {
+                "name": "Resort",
+                "region": "alps",
+                "elevation_base_m": 1000,
+                "elevation_top_m": 2000,
+                "latitude": 0.0,
+                "longitude": 0.0,
+            }
+        ] * 999  # Many resorts to make subject long
+
+        publish_new_resorts_notification(resorts, "FR", "job-123")
+
+        call_kwargs = mock_sns.publish.call_args[1]
+        assert len(call_kwargs["Subject"]) <= 100
+
+
+# ===========================================================================
+# Tests for scraper_worker_handler (Lambda entry point)
+# ===========================================================================
+
+
+class TestScraperWorkerHandler:
+    """Tests for the main Lambda handler function."""
+
+    @patch("handlers.scraper_worker.publish_new_resorts_notification")
+    @patch("handlers.scraper_worker.s3")
+    @patch("handlers.scraper_worker.get_existing_resort_ids", return_value=set())
+    @patch("handlers.scraper_worker.scrape_resort_detail")
+    @patch("handlers.scraper_worker.collect_resort_urls")
+    def test_successful_scrape(
+        self, mock_collect, mock_scrape, mock_existing, mock_s3, mock_notify
+    ):
+        mock_collect.return_value = [
+            ("https://skiresort.info/ski-resort/chamonix", "FR"),
+        ]
+        mock_scrape.return_value = {
+            "resort_id": "chamonix",
+            "name": "Chamonix",
+            "country": "FR",
+            "region": "alps",
+            "state_province": "",
+            "elevation_base_m": 1035,
+            "elevation_top_m": 3842,
+            "latitude": 45.92,
+            "longitude": 6.87,
+            "geo_hash": "u0hf",
+            "source": "skiresort.info",
+            "source_url": "https://skiresort.info/ski-resort/chamonix",
+            "scraped_at": "2026-02-21T00:00:00+00:00",
+        }
+
+        event = {"country": "FR", "delta_mode": True, "job_id": "test-job"}
+        result = scraper_worker_handler(event, None)
+
+        assert result["statusCode"] == 200
+        body = json.loads(result["body"])
+        assert body["resorts_scraped"] == 1
+        assert body["country"] == "FR"
+
+        # Verify S3 upload
+        mock_s3.put_object.assert_called_once()
+        s3_call = mock_s3.put_object.call_args[1]
+        assert "scraper-results/test-job/FR.json" in s3_call["Key"]
+        assert s3_call["ContentType"] == "application/json"
+
+    def test_invalid_country_returns_400(self):
+        event = {"country": "INVALID"}
+        result = scraper_worker_handler(event, None)
+        assert result["statusCode"] == 400
+        body = json.loads(result["body"])
+        assert "error" in body
+
+    def test_missing_country_returns_400(self):
+        event = {}
+        result = scraper_worker_handler(event, None)
+        assert result["statusCode"] == 400
+
+    @patch("handlers.scraper_worker.publish_new_resorts_notification")
+    @patch("handlers.scraper_worker.s3")
+    @patch("handlers.scraper_worker.get_existing_resort_ids", return_value={"chamonix"})
+    @patch("handlers.scraper_worker.scrape_resort_detail")
+    @patch("handlers.scraper_worker.collect_resort_urls")
+    def test_delta_mode_skips_existing_by_url_id(
+        self, mock_collect, mock_scrape, mock_existing, mock_s3, mock_notify
+    ):
+        """Delta mode should skip resorts whose URL-derived ID is already known."""
+        mock_collect.return_value = [
+            ("https://skiresort.info/ski-resort/chamonix", "FR"),
+        ]
+
+        event = {"country": "FR", "delta_mode": True, "job_id": "test-job"}
+        result = scraper_worker_handler(event, None)
+
+        body = json.loads(result["body"])
+        assert body["resorts_skipped"] == 1
+        assert body["resorts_scraped"] == 0
+        mock_scrape.assert_not_called()
+
+    @patch("handlers.scraper_worker.publish_new_resorts_notification")
+    @patch("handlers.scraper_worker.s3")
+    @patch("handlers.scraper_worker.get_existing_resort_ids", return_value={"chamonix"})
+    @patch("handlers.scraper_worker.scrape_resort_detail")
+    @patch("handlers.scraper_worker.collect_resort_urls")
+    def test_delta_mode_skips_existing_by_resort_id(
+        self, mock_collect, mock_scrape, mock_existing, mock_s3, mock_notify
+    ):
+        """Delta mode double-checks the generated resort_id against existing IDs."""
+        mock_collect.return_value = [
+            ("https://skiresort.info/ski-resort/some-other-url", "FR"),
+        ]
+        mock_scrape.return_value = {
+            "resort_id": "chamonix",
+            "name": "Chamonix",
+            "country": "FR",
+            "region": "alps",
+            "state_province": "",
+            "elevation_base_m": 1035,
+            "elevation_top_m": 3842,
+            "latitude": 45.0,
+            "longitude": 6.0,
+            "geo_hash": None,
+            "source": "skiresort.info",
+            "source_url": "url",
+            "scraped_at": "2026-02-21T00:00:00+00:00",
+        }
+
+        event = {"country": "FR", "delta_mode": True, "job_id": "test-job"}
+        result = scraper_worker_handler(event, None)
+
+        body = json.loads(result["body"])
+        assert body["resorts_skipped"] == 1
+        assert body["resorts_scraped"] == 0
+
+    @patch("handlers.scraper_worker.publish_new_resorts_notification")
+    @patch("handlers.scraper_worker.s3")
+    @patch("handlers.scraper_worker.get_existing_resort_ids", return_value=set())
+    @patch("handlers.scraper_worker.scrape_resort_detail")
+    @patch("handlers.scraper_worker.collect_resort_urls")
+    def test_delta_mode_false_does_not_fetch_existing(
+        self, mock_collect, mock_scrape, mock_existing, mock_s3, mock_notify
+    ):
+        """When delta_mode=False, we should not call get_existing_resort_ids."""
+        mock_collect.return_value = []
+
+        event = {"country": "FR", "delta_mode": False, "job_id": "test-job"}
+        scraper_worker_handler(event, None)
+
+        mock_existing.assert_not_called()
+
+    @patch("handlers.scraper_worker.publish_new_resorts_notification")
+    @patch("handlers.scraper_worker.s3")
+    @patch("handlers.scraper_worker.get_existing_resort_ids", return_value=set())
+    @patch("handlers.scraper_worker.scrape_resort_detail")
+    @patch("handlers.scraper_worker.collect_resort_urls")
+    def test_no_s3_upload_when_no_resorts(
+        self, mock_collect, mock_scrape, mock_existing, mock_s3, mock_notify
+    ):
+        """Should not upload to S3 when no resorts were scraped."""
+        mock_collect.return_value = []
+
+        event = {"country": "FR", "delta_mode": True, "job_id": "test-job"}
+        result = scraper_worker_handler(event, None)
+
+        assert result["statusCode"] == 200
+        mock_s3.put_object.assert_not_called()
+        mock_notify.assert_not_called()
+
+    @patch("handlers.scraper_worker.publish_new_resorts_notification")
+    @patch("handlers.scraper_worker.s3")
+    @patch("handlers.scraper_worker.get_existing_resort_ids", return_value=set())
+    @patch("handlers.scraper_worker.scrape_resort_detail")
+    @patch("handlers.scraper_worker.collect_resort_urls")
+    def test_handles_scrape_errors_gracefully(
+        self, mock_collect, mock_scrape, mock_existing, mock_s3, mock_notify
+    ):
+        """Individual resort scrape failures should be counted, not crash the handler."""
+        mock_collect.return_value = [
+            ("https://skiresort.info/ski-resort/resort-a", "FR"),
+            ("https://skiresort.info/ski-resort/resort-b", "FR"),
+        ]
+        mock_scrape.side_effect = [Exception("Parse error"), None]
+
+        event = {"country": "FR", "delta_mode": False, "job_id": "test-job"}
+        result = scraper_worker_handler(event, None)
+
+        assert result["statusCode"] == 200
+        body = json.loads(result["body"])
+        assert body["errors"] == 1
+        assert body["resorts_scraped"] == 0
+
+    @patch("handlers.scraper_worker.collect_resort_urls")
+    def test_fatal_error_returns_500(self, mock_collect):
+        """A fatal error in the handler should return status 500."""
+        mock_collect.side_effect = Exception("Network failure")
+
+        event = {"country": "FR", "delta_mode": False, "job_id": "test-job"}
+        result = scraper_worker_handler(event, None)
+
+        assert result["statusCode"] == 500
+        body = json.loads(result["body"])
+        assert "error" in body
+        assert "Network failure" in body["error"]
+
+    @patch("handlers.scraper_worker.publish_new_resorts_notification")
+    @patch("handlers.scraper_worker.s3")
+    @patch("handlers.scraper_worker.get_existing_resort_ids", return_value=set())
+    @patch("handlers.scraper_worker.scrape_resort_detail")
+    @patch("handlers.scraper_worker.collect_resort_urls")
+    def test_default_job_id_when_not_provided(
+        self, mock_collect, mock_scrape, mock_existing, mock_s3, mock_notify
+    ):
+        """job_id should default to a timestamp when not provided."""
+        mock_collect.return_value = [
+            ("https://skiresort.info/ski-resort/resort-a", "FR"),
+        ]
+        mock_scrape.return_value = {
+            "resort_id": "resort-a",
+            "name": "Resort A",
+            "country": "FR",
+            "region": "alps",
+            "state_province": "",
+            "elevation_base_m": 1000,
+            "elevation_top_m": 3000,
+            "latitude": 45.0,
+            "longitude": 6.0,
+            "geo_hash": None,
+            "source": "skiresort.info",
+            "source_url": "url",
+            "scraped_at": "2026-02-21T00:00:00+00:00",
+        }
+
+        event = {"country": "FR", "delta_mode": False}
+        result = scraper_worker_handler(event, None)
+
+        assert result["statusCode"] == 200
+        # S3 key should contain a timestamp-based job_id
+        s3_call = mock_s3.put_object.call_args[1]
+        assert "scraper-results/" in s3_call["Key"]
+        assert "/FR.json" in s3_call["Key"]
+
+    @patch("handlers.scraper_worker.publish_new_resorts_notification")
+    @patch("handlers.scraper_worker.s3")
+    @patch("handlers.scraper_worker.get_existing_resort_ids", return_value=set())
+    @patch("handlers.scraper_worker.scrape_resort_detail")
+    @patch("handlers.scraper_worker.collect_resort_urls")
+    def test_duration_seconds_in_response(
+        self, mock_collect, mock_scrape, mock_existing, mock_s3, mock_notify
+    ):
+        """Response body should include duration_seconds."""
+        mock_collect.return_value = []
+
+        event = {"country": "FR", "delta_mode": False, "job_id": "test-job"}
+        result = scraper_worker_handler(event, None)
+
+        body = json.loads(result["body"])
+        assert "duration_seconds" in body
+        assert isinstance(body["duration_seconds"], int | float)
+
+    @patch("handlers.scraper_worker.publish_new_resorts_notification")
+    @patch("handlers.scraper_worker.s3")
+    @patch("handlers.scraper_worker.get_existing_resort_ids", return_value=set())
+    @patch("handlers.scraper_worker.scrape_resort_detail")
+    @patch("handlers.scraper_worker.collect_resort_urls")
+    def test_sends_sns_notification_on_success(
+        self, mock_collect, mock_scrape, mock_existing, mock_s3, mock_notify
+    ):
+        """Should call publish_new_resorts_notification when resorts are found."""
+        mock_collect.return_value = [
+            ("https://skiresort.info/ski-resort/test", "FR"),
+        ]
+        resort_data = {
+            "resort_id": "test",
+            "name": "Test",
+            "country": "FR",
+            "region": "alps",
+            "state_province": "",
+            "elevation_base_m": 1000,
+            "elevation_top_m": 3000,
+            "latitude": 45.0,
+            "longitude": 6.0,
+            "geo_hash": None,
+            "source": "skiresort.info",
+            "source_url": "url",
+            "scraped_at": "2026-02-21T00:00:00+00:00",
+        }
+        mock_scrape.return_value = resort_data
+
+        event = {"country": "FR", "delta_mode": False, "job_id": "test-job"}
+        scraper_worker_handler(event, None)
+
+        mock_notify.assert_called_once()
+        call_args = mock_notify.call_args[0]
+        assert len(call_args[0]) == 1  # resorts list
+        assert call_args[1] == "FR"  # country
+        assert call_args[2] == "test-job"  # job_id
+
+    @patch("handlers.scraper_worker.publish_new_resorts_notification")
+    @patch("handlers.scraper_worker.s3")
+    @patch("handlers.scraper_worker.get_existing_resort_ids", return_value=set())
+    @patch("handlers.scraper_worker.scrape_resort_detail")
+    @patch("handlers.scraper_worker.collect_resort_urls")
+    def test_s3_body_contains_resorts_and_stats(
+        self, mock_collect, mock_scrape, mock_existing, mock_s3, mock_notify
+    ):
+        """S3 upload body should contain both resorts list and stats."""
+        mock_collect.return_value = [
+            ("https://skiresort.info/ski-resort/test", "FR"),
+        ]
+        resort_data = {
+            "resort_id": "test",
+            "name": "Test",
+            "country": "FR",
+            "region": "alps",
+            "state_province": "",
+            "elevation_base_m": 1000,
+            "elevation_top_m": 3000,
+            "latitude": 45.0,
+            "longitude": 6.0,
+            "geo_hash": None,
+            "source": "skiresort.info",
+            "source_url": "url",
+            "scraped_at": "2026-02-21T00:00:00+00:00",
+        }
+        mock_scrape.return_value = resort_data
+
+        event = {"country": "FR", "delta_mode": False, "job_id": "test-job"}
+        scraper_worker_handler(event, None)
+
+        s3_body = json.loads(mock_s3.put_object.call_args[1]["Body"])
+        assert "resorts" in s3_body
+        assert "stats" in s3_body
+        assert len(s3_body["resorts"]) == 1
+        assert s3_body["stats"]["country"] == "FR"
+        assert s3_body["stats"]["resorts_scraped"] == 1
+
+    @patch("handlers.scraper_worker.publish_new_resorts_notification")
+    @patch("handlers.scraper_worker.s3")
+    @patch("handlers.scraper_worker.get_existing_resort_ids", return_value=set())
+    @patch("handlers.scraper_worker.scrape_resort_detail")
+    @patch("handlers.scraper_worker.collect_resort_urls")
+    def test_scrape_returns_none_not_counted(
+        self, mock_collect, mock_scrape, mock_existing, mock_s3, mock_notify
+    ):
+        """Resorts where scrape_resort_detail returns None should not be counted."""
+        mock_collect.return_value = [
+            ("https://skiresort.info/ski-resort/resort-a", "FR"),
+            ("https://skiresort.info/ski-resort/resort-b", "FR"),
+        ]
+        mock_scrape.return_value = (
+            None  # Both return None (e.g., insufficient vertical)
+        )
+
+        event = {"country": "FR", "delta_mode": False, "job_id": "test-job"}
+        result = scraper_worker_handler(event, None)
+
+        body = json.loads(result["body"])
+        assert body["resorts_scraped"] == 0
+        assert body["errors"] == 0
+        mock_s3.put_object.assert_not_called()
+
+
+# ===========================================================================
+# Tests for COUNTRY_URLS and REGION_MAPPINGS consistency
+# ===========================================================================
+
+
+class TestMappingConsistency:
+    """Tests for consistency between various mappings."""
+
+    def test_all_country_urls_have_region_mappings(self):
+        """Every country in COUNTRY_URLS should have a REGION_MAPPINGS entry."""
+        for country in COUNTRY_URLS:
+            assert country in REGION_MAPPINGS, (
+                f"Country {country} in COUNTRY_URLS but missing from REGION_MAPPINGS"
+            )
+
+    def test_all_us_states_map_to_valid_regions(self):
+        valid_regions = {"na_west", "na_rockies", "na_east", "na_midwest"}
+        for state, region in US_STATE_REGIONS.items():
+            assert region in valid_regions, (
+                f"US state {state} maps to invalid region {region}"
+            )
+
+    def test_all_ca_provinces_map_to_valid_regions(self):
+        valid_regions = {"na_west", "na_rockies", "na_east"}
+        for province, region in CA_PROVINCE_REGIONS.items():
+            assert region in valid_regions, (
+                f"CA province {province} maps to invalid region {region}"
+            )
+
+    def test_country_urls_are_valid_paths(self):
+        for country, path in COUNTRY_URLS.items():
+            assert path.startswith("/ski-resorts/"), (
+                f"Country {country} URL path should start with /ski-resorts/"
+            )
+
+
+# ===========================================================================
+# Tests for elevation extraction edge cases
+# ===========================================================================
+
+
+class TestElevationExtraction:
+    """Tests for various elevation extraction patterns in scrape_resort_detail."""
+
+    @patch("handlers.scraper_worker.geocode_resort", return_value=(45.0, 6.0))
+    @patch("handlers.scraper_worker.time.sleep")
+    @patch("handlers.scraper_worker.time.time", return_value=0)
+    def test_elevation_from_range_with_dash(self, mock_time, mock_sleep, mock_geocode):
+        """Should extract elevation from '1035 m - 3842 m' pattern."""
+        html = (
+            "<html><body><h1>Test Resort</h1><div>1035 m - 3842 m</div></body></html>"
+        )
+        session = ScraperSession()
+        session._last_request_time = 0
+        mock_resp = Mock()
+        mock_resp.raise_for_status = Mock()
+        mock_resp.text = html
+        session.session = Mock()
+        session.session.get.return_value = mock_resp
+
+        result = scrape_resort_detail(session, "https://example.com", "FR")
+        assert result is not None
+        assert result["elevation_base_m"] == 1035
+        assert result["elevation_top_m"] == 3842
+
+    @patch("handlers.scraper_worker.geocode_resort", return_value=(45.0, 6.0))
+    @patch("handlers.scraper_worker.time.sleep")
+    @patch("handlers.scraper_worker.time.time", return_value=0)
+    def test_elevation_from_altitude_section(self, mock_time, mock_sleep, mock_geocode):
+        """Should extract elevation when there's an 'altitude' label."""
+        html = """<html><body>
+        <h1>Test Resort</h1>
+        <div><span>Altitude</span><div>800 m and 2500 m available</div></div>
+        </body></html>"""
+        session = ScraperSession()
+        session._last_request_time = 0
+        mock_resp = Mock()
+        mock_resp.raise_for_status = Mock()
+        mock_resp.text = html
+        session.session = Mock()
+        session.session.get.return_value = mock_resp
+
+        result = scrape_resort_detail(session, "https://example.com", "FR")
+        assert result is not None
+        assert result["elevation_base_m"] == 800
+        assert result["elevation_top_m"] == 2500
+
+    @patch("handlers.scraper_worker.geocode_resort", return_value=(45.0, 6.0))
+    @patch("handlers.scraper_worker.time.sleep")
+    @patch("handlers.scraper_worker.time.time", return_value=0)
+    def test_elevation_with_en_dash(self, mock_time, mock_sleep, mock_geocode):
+        """Should handle en-dash in elevation range."""
+        html = "<html><body><h1>Test Resort</h1><div>1500 m \u2013 3500 m</div></body></html>"
+        session = ScraperSession()
+        session._last_request_time = 0
+        mock_resp = Mock()
+        mock_resp.raise_for_status = Mock()
+        mock_resp.text = html
+        session.session = Mock()
+        session.session.get.return_value = mock_resp
+
+        result = scrape_resort_detail(session, "https://example.com", "FR")
+        assert result is not None
+        assert result["elevation_base_m"] == 1500
+        assert result["elevation_top_m"] == 3500

--- a/backend/tests/test_version_consolidator.py
+++ b/backend/tests/test_version_consolidator.py
@@ -1,0 +1,1301 @@
+"""Comprehensive tests for the version_consolidator Lambda handler."""
+
+import io
+import json
+from datetime import UTC, datetime
+from types import SimpleNamespace
+from unittest.mock import MagicMock, Mock, call, patch
+
+import pytest
+
+MODULE = "handlers.version_consolidator"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_resort_dict(
+    resort_id="whistler",
+    name="Whistler Blackcomb",
+    country="CA",
+    region="na_west",
+    latitude=50.1163,
+    longitude=-122.9574,
+    elevation_base_m=675,
+    elevation_top_m=2284,
+):
+    """Create a resort dict as returned by the scraper."""
+    return {
+        "resort_id": resort_id,
+        "name": name,
+        "country": country,
+        "region": region,
+        "latitude": latitude,
+        "longitude": longitude,
+        "elevation_base_m": elevation_base_m,
+        "elevation_top_m": elevation_top_m,
+    }
+
+
+def _make_production_resort(
+    resort_id="whistler",
+    name="Whistler Blackcomb",
+    country="CA",
+    region="na_west",
+    elevation_base_m=675,
+    elevation_top_m=2284,
+    elevation_points=None,
+):
+    """Create a production resort dict as returned by DynamoDB."""
+    data = {
+        "resort_id": resort_id,
+        "name": name,
+        "country": country,
+        "region": region,
+        "elevation_base_m": elevation_base_m,
+        "elevation_top_m": elevation_top_m,
+    }
+    if elevation_points is not None:
+        data["elevation_points"] = elevation_points
+    return data
+
+
+def _make_s3_body(data):
+    """Create a mock S3 Body object from a dict."""
+    body = io.BytesIO(json.dumps(data).encode("utf-8"))
+    return body
+
+
+def _make_lambda_context():
+    """Create a mock Lambda context object."""
+    ctx = SimpleNamespace()
+    ctx.get_remaining_time_in_millis = lambda: 300000
+    return ctx
+
+
+# ---------------------------------------------------------------------------
+# Tests for get_latest_scraper_job_id
+# ---------------------------------------------------------------------------
+
+
+class TestGetLatestScraperJobId:
+    """Tests for finding the most recent scraper job ID from S3."""
+
+    @patch(f"{MODULE}.s3")
+    def test_returns_latest_job_id(self, mock_s3):
+        from handlers.version_consolidator import get_latest_scraper_job_id
+
+        mock_s3.list_objects_v2.return_value = {
+            "CommonPrefixes": [
+                {"Prefix": "scraper-results/20260201060000/"},
+                {"Prefix": "scraper-results/20260203060000/"},
+                {"Prefix": "scraper-results/20260202060000/"},
+            ]
+        }
+
+        result = get_latest_scraper_job_id()
+        assert result == "20260203060000"
+
+    @patch(f"{MODULE}.s3")
+    def test_returns_none_when_no_prefixes(self, mock_s3):
+        from handlers.version_consolidator import get_latest_scraper_job_id
+
+        mock_s3.list_objects_v2.return_value = {"CommonPrefixes": []}
+        result = get_latest_scraper_job_id()
+        assert result is None
+
+    @patch(f"{MODULE}.s3")
+    def test_returns_none_when_no_common_prefixes_key(self, mock_s3):
+        from handlers.version_consolidator import get_latest_scraper_job_id
+
+        mock_s3.list_objects_v2.return_value = {}
+        result = get_latest_scraper_job_id()
+        assert result is None
+
+    @patch(f"{MODULE}.s3")
+    def test_skips_test_jobs(self, mock_s3):
+        from handlers.version_consolidator import get_latest_scraper_job_id
+
+        mock_s3.list_objects_v2.return_value = {
+            "CommonPrefixes": [
+                {"Prefix": "scraper-results/test-run-1/"},
+                {"Prefix": "scraper-results/20260201060000/"},
+                {"Prefix": "scraper-results/test-run-2/"},
+            ]
+        }
+
+        result = get_latest_scraper_job_id()
+        assert result == "20260201060000"
+
+    @patch(f"{MODULE}.s3")
+    def test_returns_none_when_only_test_jobs(self, mock_s3):
+        from handlers.version_consolidator import get_latest_scraper_job_id
+
+        mock_s3.list_objects_v2.return_value = {
+            "CommonPrefixes": [
+                {"Prefix": "scraper-results/test-run-1/"},
+                {"Prefix": "scraper-results/test-run-2/"},
+            ]
+        }
+
+        result = get_latest_scraper_job_id()
+        assert result is None
+
+    @patch(f"{MODULE}.s3")
+    def test_returns_none_on_s3_error(self, mock_s3):
+        from handlers.version_consolidator import get_latest_scraper_job_id
+
+        mock_s3.list_objects_v2.side_effect = RuntimeError("S3 connection error")
+        result = get_latest_scraper_job_id()
+        assert result is None
+
+    @patch(f"{MODULE}.s3")
+    def test_filters_empty_job_ids(self, mock_s3):
+        """Prefixes that split to empty string should be filtered."""
+        from handlers.version_consolidator import get_latest_scraper_job_id
+
+        mock_s3.list_objects_v2.return_value = {
+            "CommonPrefixes": [
+                {"Prefix": "scraper-results//"},  # empty job id
+                {"Prefix": "scraper-results/20260201060000/"},
+            ]
+        }
+
+        result = get_latest_scraper_job_id()
+        assert result == "20260201060000"
+
+
+# ---------------------------------------------------------------------------
+# Tests for get_scraper_results
+# ---------------------------------------------------------------------------
+
+
+class TestGetScraperResults:
+    """Tests for aggregating scraper results from S3."""
+
+    @patch(f"{MODULE}.s3")
+    def test_loads_country_results(self, mock_s3):
+        from handlers.version_consolidator import get_scraper_results
+
+        us_data = {
+            "resorts": [
+                _make_resort_dict("vail", "Vail", "US", "na_rockies"),
+                _make_resort_dict("park-city", "Park City", "US", "na_rockies"),
+            ],
+            "stats": {"resorts_scraped": 2, "resorts_skipped": 0, "errors": 0},
+        }
+        ca_data = {
+            "resorts": [
+                _make_resort_dict("whistler", "Whistler", "CA", "na_west"),
+            ],
+            "stats": {"resorts_scraped": 1, "resorts_skipped": 1, "errors": 0},
+        }
+
+        # Mock paginator
+        paginator = MagicMock()
+        mock_s3.get_paginator.return_value = paginator
+        paginator.paginate.return_value = [
+            {
+                "Contents": [
+                    {"Key": "scraper-results/job123/US.json"},
+                    {"Key": "scraper-results/job123/CA.json"},
+                ]
+            }
+        ]
+
+        mock_s3.get_object.side_effect = [
+            {"Body": _make_s3_body(us_data)},
+            {"Body": _make_s3_body(ca_data)},
+        ]
+
+        resorts, stats_by_country = get_scraper_results("job123")
+
+        assert len(resorts) == 3
+        assert "US" in stats_by_country
+        assert "CA" in stats_by_country
+        assert stats_by_country["US"]["count"] == 2
+        assert stats_by_country["US"]["scraped"] == 2
+        assert stats_by_country["CA"]["count"] == 1
+        assert stats_by_country["CA"]["skipped"] == 1
+
+    @patch(f"{MODULE}.s3")
+    def test_skips_metadata_files(self, mock_s3):
+        from handlers.version_consolidator import get_scraper_results
+
+        us_data = {
+            "resorts": [_make_resort_dict("vail", "Vail", "US")],
+            "stats": {"resorts_scraped": 1},
+        }
+
+        paginator = MagicMock()
+        mock_s3.get_paginator.return_value = paginator
+        paginator.paginate.return_value = [
+            {
+                "Contents": [
+                    {"Key": "scraper-results/job123/US.json"},
+                    {"Key": "scraper-results/job123/US_metadata.json"},
+                    {"Key": "scraper-results/job123/job_metadata.json"},
+                ]
+            }
+        ]
+
+        mock_s3.get_object.return_value = {"Body": _make_s3_body(us_data)}
+
+        resorts, stats_by_country = get_scraper_results("job123")
+
+        assert len(resorts) == 1
+        # get_object should only be called once (for US.json)
+        assert mock_s3.get_object.call_count == 1
+
+    @patch(f"{MODULE}.s3")
+    def test_skips_non_json_files(self, mock_s3):
+        from handlers.version_consolidator import get_scraper_results
+
+        us_data = {
+            "resorts": [_make_resort_dict("vail", "Vail", "US")],
+            "stats": {},
+        }
+
+        paginator = MagicMock()
+        mock_s3.get_paginator.return_value = paginator
+        paginator.paginate.return_value = [
+            {
+                "Contents": [
+                    {"Key": "scraper-results/job123/US.json"},
+                    {"Key": "scraper-results/job123/readme.txt"},
+                    {"Key": "scraper-results/job123/log.csv"},
+                ]
+            }
+        ]
+
+        mock_s3.get_object.return_value = {"Body": _make_s3_body(us_data)}
+
+        resorts, stats_by_country = get_scraper_results("job123")
+
+        assert len(resorts) == 1
+        assert mock_s3.get_object.call_count == 1
+
+    @patch(f"{MODULE}.s3")
+    def test_handles_empty_contents(self, mock_s3):
+        from handlers.version_consolidator import get_scraper_results
+
+        paginator = MagicMock()
+        mock_s3.get_paginator.return_value = paginator
+        paginator.paginate.return_value = [{"Contents": []}]
+
+        resorts, stats_by_country = get_scraper_results("job123")
+
+        assert len(resorts) == 0
+        assert len(stats_by_country) == 0
+
+    @patch(f"{MODULE}.s3")
+    def test_handles_no_contents_key(self, mock_s3):
+        from handlers.version_consolidator import get_scraper_results
+
+        paginator = MagicMock()
+        mock_s3.get_paginator.return_value = paginator
+        paginator.paginate.return_value = [{}]  # no "Contents" key
+
+        resorts, stats_by_country = get_scraper_results("job123")
+
+        assert len(resorts) == 0
+        assert len(stats_by_country) == 0
+
+    @patch(f"{MODULE}.s3")
+    def test_handles_individual_file_read_error(self, mock_s3):
+        """If one file fails to read, others should still be processed."""
+        from handlers.version_consolidator import get_scraper_results
+
+        ca_data = {
+            "resorts": [_make_resort_dict("whistler", "Whistler", "CA")],
+            "stats": {"resorts_scraped": 1},
+        }
+
+        paginator = MagicMock()
+        mock_s3.get_paginator.return_value = paginator
+        paginator.paginate.return_value = [
+            {
+                "Contents": [
+                    {"Key": "scraper-results/job123/US.json"},
+                    {"Key": "scraper-results/job123/CA.json"},
+                ]
+            }
+        ]
+
+        mock_s3.get_object.side_effect = [
+            RuntimeError("S3 read error"),  # US.json fails
+            {"Body": _make_s3_body(ca_data)},  # CA.json succeeds
+        ]
+
+        resorts, stats_by_country = get_scraper_results("job123")
+
+        assert len(resorts) == 1
+        assert resorts[0]["resort_id"] == "whistler"
+        assert "CA" in stats_by_country
+        assert "US" not in stats_by_country
+
+    @patch(f"{MODULE}.s3")
+    def test_handles_paginator_error(self, mock_s3):
+        from handlers.version_consolidator import get_scraper_results
+
+        mock_s3.get_paginator.side_effect = RuntimeError("S3 listing error")
+
+        resorts, stats_by_country = get_scraper_results("job123")
+
+        assert len(resorts) == 0
+        assert len(stats_by_country) == 0
+
+    @patch(f"{MODULE}.s3")
+    def test_multiple_pages(self, mock_s3):
+        from handlers.version_consolidator import get_scraper_results
+
+        us_data = {
+            "resorts": [_make_resort_dict("vail", "Vail", "US")],
+            "stats": {"resorts_scraped": 1},
+        }
+        ch_data = {
+            "resorts": [_make_resort_dict("zermatt", "Zermatt", "CH", "alps")],
+            "stats": {"resorts_scraped": 1},
+        }
+
+        paginator = MagicMock()
+        mock_s3.get_paginator.return_value = paginator
+        paginator.paginate.return_value = [
+            {"Contents": [{"Key": "scraper-results/job123/US.json"}]},
+            {"Contents": [{"Key": "scraper-results/job123/CH.json"}]},
+        ]
+
+        mock_s3.get_object.side_effect = [
+            {"Body": _make_s3_body(us_data)},
+            {"Body": _make_s3_body(ch_data)},
+        ]
+
+        resorts, stats_by_country = get_scraper_results("job123")
+
+        assert len(resorts) == 2
+        assert "US" in stats_by_country
+        assert "CH" in stats_by_country
+
+    @patch(f"{MODULE}.s3")
+    def test_stats_defaults_for_missing_fields(self, mock_s3):
+        """Stats fields that are missing from the source should default to 0."""
+        from handlers.version_consolidator import get_scraper_results
+
+        data = {
+            "resorts": [_make_resort_dict("vail", "Vail", "US")],
+            "stats": {},  # empty stats
+        }
+
+        paginator = MagicMock()
+        mock_s3.get_paginator.return_value = paginator
+        paginator.paginate.return_value = [
+            {"Contents": [{"Key": "scraper-results/job123/US.json"}]}
+        ]
+        mock_s3.get_object.return_value = {"Body": _make_s3_body(data)}
+
+        resorts, stats_by_country = get_scraper_results("job123")
+
+        assert stats_by_country["US"]["scraped"] == 0
+        assert stats_by_country["US"]["skipped"] == 0
+        assert stats_by_country["US"]["errors"] == 0
+
+
+# ---------------------------------------------------------------------------
+# Tests for get_production_resorts
+# ---------------------------------------------------------------------------
+
+
+class TestGetProductionResorts:
+    """Tests for reading production resort data from DynamoDB."""
+
+    @patch(f"{MODULE}.dynamodb")
+    def test_returns_resorts_by_id(self, mock_ddb):
+        from handlers.version_consolidator import get_production_resorts
+
+        table = MagicMock()
+        mock_ddb.Table.return_value = table
+        table.scan.return_value = {
+            "Items": [
+                {"resort_id": "whistler", "name": "Whistler"},
+                {"resort_id": "vail", "name": "Vail"},
+            ]
+        }
+
+        result = get_production_resorts()
+
+        assert len(result) == 2
+        assert "whistler" in result
+        assert "vail" in result
+        assert result["whistler"]["name"] == "Whistler"
+
+    @patch(f"{MODULE}.dynamodb")
+    def test_handles_pagination(self, mock_ddb):
+        from handlers.version_consolidator import get_production_resorts
+
+        table = MagicMock()
+        mock_ddb.Table.return_value = table
+        table.scan.side_effect = [
+            {
+                "Items": [{"resort_id": "whistler", "name": "Whistler"}],
+                "LastEvaluatedKey": {"resort_id": "whistler"},
+            },
+            {
+                "Items": [{"resort_id": "vail", "name": "Vail"}],
+            },
+        ]
+
+        result = get_production_resorts()
+
+        assert len(result) == 2
+        assert table.scan.call_count == 2
+
+    @patch(f"{MODULE}.dynamodb")
+    def test_handles_empty_table(self, mock_ddb):
+        from handlers.version_consolidator import get_production_resorts
+
+        table = MagicMock()
+        mock_ddb.Table.return_value = table
+        table.scan.return_value = {"Items": []}
+
+        result = get_production_resorts()
+        assert len(result) == 0
+
+    @patch(f"{MODULE}.dynamodb")
+    def test_skips_items_without_resort_id(self, mock_ddb):
+        from handlers.version_consolidator import get_production_resorts
+
+        table = MagicMock()
+        mock_ddb.Table.return_value = table
+        table.scan.return_value = {
+            "Items": [
+                {"resort_id": "whistler", "name": "Whistler"},
+                {"name": "Unknown"},  # no resort_id
+            ]
+        }
+
+        result = get_production_resorts()
+        assert len(result) == 1
+        assert "whistler" in result
+
+    @patch(f"{MODULE}.dynamodb")
+    def test_handles_scan_error(self, mock_ddb):
+        from handlers.version_consolidator import get_production_resorts
+
+        table = MagicMock()
+        mock_ddb.Table.return_value = table
+        table.scan.side_effect = RuntimeError("DynamoDB error")
+
+        result = get_production_resorts()
+        assert len(result) == 0
+
+
+# ---------------------------------------------------------------------------
+# Tests for calculate_diff
+# ---------------------------------------------------------------------------
+
+
+class TestCalculateDiff:
+    """Tests for diff calculation between new scraper data and production."""
+
+    def test_all_new_resorts(self):
+        from handlers.version_consolidator import calculate_diff
+
+        new_resorts = [
+            _make_resort_dict("whistler", "Whistler", "CA", "na_west"),
+            _make_resort_dict("vail", "Vail", "US", "na_rockies"),
+        ]
+        production_resorts = {}
+
+        diff = calculate_diff(new_resorts, production_resorts)
+
+        assert len(diff["added"]) == 2
+        assert len(diff["removed"]) == 0
+        assert len(diff["modified"]) == 0
+        assert diff["unchanged_count"] == 0
+
+    def test_all_removed_resorts(self):
+        from handlers.version_consolidator import calculate_diff
+
+        new_resorts = []
+        production_resorts = {
+            "whistler": _make_production_resort("whistler", "Whistler"),
+            "vail": _make_production_resort("vail", "Vail"),
+        }
+
+        diff = calculate_diff(new_resorts, production_resorts)
+
+        assert len(diff["added"]) == 0
+        assert len(diff["removed"]) == 2
+        assert len(diff["modified"]) == 0
+
+    def test_no_changes(self):
+        from handlers.version_consolidator import calculate_diff
+
+        new_resorts = [
+            _make_resort_dict("whistler", "Whistler", "CA", "na_west"),
+        ]
+        production_resorts = {
+            "whistler": _make_production_resort(
+                "whistler",
+                "Whistler",
+                elevation_base_m=675,
+                elevation_top_m=2284,
+            ),
+        }
+
+        diff = calculate_diff(new_resorts, production_resorts)
+
+        assert len(diff["added"]) == 0
+        assert len(diff["removed"]) == 0
+        assert len(diff["modified"]) == 0
+        assert diff["unchanged_count"] == 1
+
+    def test_modified_name(self):
+        from handlers.version_consolidator import calculate_diff
+
+        new_resorts = [
+            _make_resort_dict("whistler", "Whistler Blackcomb Resort"),
+        ]
+        production_resorts = {
+            "whistler": _make_production_resort("whistler", "Whistler Blackcomb"),
+        }
+
+        diff = calculate_diff(new_resorts, production_resorts)
+
+        assert len(diff["modified"]) == 1
+        assert diff["modified"][0]["resort_id"] == "whistler"
+        assert any("name:" in c for c in diff["modified"][0]["changes"])
+
+    def test_modified_base_elevation(self):
+        from handlers.version_consolidator import calculate_diff
+
+        new_resorts = [
+            _make_resort_dict("whistler", "Whistler", elevation_base_m=700),
+        ]
+        production_resorts = {
+            "whistler": _make_production_resort(
+                "whistler", "Whistler", elevation_base_m=675
+            ),
+        }
+
+        diff = calculate_diff(new_resorts, production_resorts)
+
+        assert len(diff["modified"]) == 1
+        assert any("base_elev:" in c for c in diff["modified"][0]["changes"])
+
+    def test_modified_top_elevation(self):
+        from handlers.version_consolidator import calculate_diff
+
+        new_resorts = [
+            _make_resort_dict("whistler", "Whistler", elevation_top_m=2300),
+        ]
+        production_resorts = {
+            "whistler": _make_production_resort(
+                "whistler", "Whistler", elevation_top_m=2284
+            ),
+        }
+
+        diff = calculate_diff(new_resorts, production_resorts)
+
+        assert len(diff["modified"]) == 1
+        assert any("top_elev:" in c for c in diff["modified"][0]["changes"])
+
+    def test_elevation_comparison_with_elevation_points_base(self):
+        """Production resort using nested elevation_points structure for base."""
+        from handlers.version_consolidator import calculate_diff
+
+        new_resorts = [
+            _make_resort_dict("whistler", "Whistler", elevation_base_m=675),
+        ]
+        production_resorts = {
+            "whistler": {
+                "resort_id": "whistler",
+                "name": "Whistler",
+                "elevation_base_m": None,
+                "elevation_top_m": 2284,
+                "elevation_points": [
+                    {"level": "base", "elevation_meters": 675},
+                    {"level": "top", "elevation_meters": 2284},
+                ],
+            },
+        }
+
+        diff = calculate_diff(new_resorts, production_resorts)
+
+        # Base elevation matches through elevation_points fallback
+        assert len(diff["modified"]) == 0
+
+    def test_elevation_comparison_with_elevation_points_top(self):
+        """Production resort using nested elevation_points structure for top."""
+        from handlers.version_consolidator import calculate_diff
+
+        new_resorts = [
+            _make_resort_dict("whistler", "Whistler", elevation_top_m=2284),
+        ]
+        production_resorts = {
+            "whistler": {
+                "resort_id": "whistler",
+                "name": "Whistler",
+                "elevation_base_m": 675,
+                "elevation_top_m": None,
+                "elevation_points": [
+                    {"level": "base", "elevation_meters": 675},
+                    {"level": "top", "elevation_meters": 2284},
+                ],
+            },
+        }
+
+        diff = calculate_diff(new_resorts, production_resorts)
+
+        assert len(diff["modified"]) == 0
+
+    def test_elevation_points_fallback_detects_change(self):
+        """When elevation_points has a different value, change should be detected."""
+        from handlers.version_consolidator import calculate_diff
+
+        new_resorts = [
+            _make_resort_dict("whistler", "Whistler", elevation_base_m=700),
+        ]
+        production_resorts = {
+            "whistler": {
+                "resort_id": "whistler",
+                "name": "Whistler",
+                "elevation_base_m": None,
+                "elevation_top_m": 2284,
+                "elevation_points": [
+                    {"level": "base", "elevation_meters": 675},
+                    {"level": "top", "elevation_meters": 2284},
+                ],
+            },
+        }
+
+        diff = calculate_diff(new_resorts, production_resorts)
+
+        assert len(diff["modified"]) == 1
+        assert any("base_elev:" in c for c in diff["modified"][0]["changes"])
+
+    def test_mixed_add_remove_modify(self):
+        from handlers.version_consolidator import calculate_diff
+
+        new_resorts = [
+            _make_resort_dict("whistler", "Whistler Updated"),  # modified
+            _make_resort_dict("zermatt", "Zermatt", "CH", "alps"),  # added
+        ]
+        production_resorts = {
+            "whistler": _make_production_resort("whistler", "Whistler"),
+            "vail": _make_production_resort(
+                "vail", "Vail", "US", "na_rockies"
+            ),  # removed
+        }
+
+        diff = calculate_diff(new_resorts, production_resorts)
+
+        assert len(diff["added"]) == 1
+        assert diff["added"][0]["resort_id"] == "zermatt"
+        assert len(diff["removed"]) == 1
+        assert diff["removed"][0]["resort_id"] == "vail"
+        assert len(diff["modified"]) == 1
+        assert diff["modified"][0]["resort_id"] == "whistler"
+        assert diff["unchanged_count"] == 0
+
+    def test_added_resorts_sorted_by_id(self):
+        from handlers.version_consolidator import calculate_diff
+
+        new_resorts = [
+            _make_resort_dict("zermatt", "Zermatt"),
+            _make_resort_dict("aspen", "Aspen"),
+            _make_resort_dict("mammoth", "Mammoth"),
+        ]
+        production_resorts = {}
+
+        diff = calculate_diff(new_resorts, production_resorts)
+
+        ids = [r["resort_id"] for r in diff["added"]]
+        assert ids == sorted(ids)
+
+    def test_removed_resorts_sorted_by_id(self):
+        from handlers.version_consolidator import calculate_diff
+
+        new_resorts = []
+        production_resorts = {
+            "zermatt": _make_production_resort("zermatt", "Zermatt"),
+            "aspen": _make_production_resort("aspen", "Aspen"),
+            "mammoth": _make_production_resort("mammoth", "Mammoth"),
+        }
+
+        diff = calculate_diff(new_resorts, production_resorts)
+
+        ids = [r["resort_id"] for r in diff["removed"]]
+        assert ids == sorted(ids)
+
+    def test_multiple_changes_on_one_resort(self):
+        from handlers.version_consolidator import calculate_diff
+
+        new_resorts = [
+            _make_resort_dict(
+                "whistler",
+                "Whistler Updated",
+                elevation_base_m=700,
+                elevation_top_m=2300,
+            ),
+        ]
+        production_resorts = {
+            "whistler": _make_production_resort(
+                "whistler",
+                "Whistler",
+                elevation_base_m=675,
+                elevation_top_m=2284,
+            ),
+        }
+
+        diff = calculate_diff(new_resorts, production_resorts)
+
+        assert len(diff["modified"]) == 1
+        changes = diff["modified"][0]["changes"]
+        assert len(changes) == 3  # name, base_elev, top_elev
+
+
+# ---------------------------------------------------------------------------
+# Tests for generate_stats
+# ---------------------------------------------------------------------------
+
+
+class TestGenerateStats:
+    """Tests for resort dataset statistics generation."""
+
+    def test_basic_stats(self):
+        from handlers.version_consolidator import generate_stats
+
+        resorts = [
+            _make_resort_dict("whistler", "Whistler", "CA", "na_west"),
+            _make_resort_dict("vail", "Vail", "US", "na_rockies"),
+            _make_resort_dict("park-city", "Park City", "US", "na_rockies"),
+        ]
+        stats_by_country = {
+            "CA": {"count": 1, "scraped": 1, "skipped": 0, "errors": 0},
+            "US": {"count": 2, "scraped": 2, "skipped": 0, "errors": 0},
+        }
+
+        stats = generate_stats(resorts, stats_by_country)
+
+        assert stats["total_resorts"] == 3
+        assert stats["by_country"]["CA"] == 1
+        assert stats["by_country"]["US"] == 2
+        assert stats["by_region"]["na_west"] == 1
+        assert stats["by_region"]["na_rockies"] == 2
+        assert stats["scraper_stats"] == stats_by_country
+
+    def test_with_valid_coordinates(self):
+        from handlers.version_consolidator import generate_stats
+
+        resorts = [
+            _make_resort_dict("whistler", latitude=50.1, longitude=-122.9),
+            _make_resort_dict("vail", latitude=39.6, longitude=-106.4),
+            {
+                "resort_id": "unknown",
+                "name": "Unknown",
+                "country": "XX",
+                "region": "xx",
+                "latitude": 0,
+                "longitude": 0,
+            },
+        ]
+
+        stats = generate_stats(resorts, {})
+
+        assert stats["with_valid_coordinates"] == 2
+
+    def test_empty_resorts(self):
+        from handlers.version_consolidator import generate_stats
+
+        stats = generate_stats([], {})
+
+        assert stats["total_resorts"] == 0
+        assert stats["by_country"] == {}
+        assert stats["by_region"] == {}
+        assert stats["with_valid_coordinates"] == 0
+
+    def test_unknown_country_and_region(self):
+        from handlers.version_consolidator import generate_stats
+
+        resorts = [
+            {"resort_id": "x", "name": "X"},  # no country/region keys
+        ]
+
+        stats = generate_stats(resorts, {})
+
+        assert stats["by_country"]["unknown"] == 1
+        assert stats["by_region"]["unknown"] == 1
+
+    def test_coordinates_with_nonzero_latitude_only(self):
+        """A resort with latitude != 0 but longitude == 0 counts as valid."""
+        from handlers.version_consolidator import generate_stats
+
+        resorts = [
+            {
+                "resort_id": "eq",
+                "name": "Equator",
+                "country": "XX",
+                "region": "xx",
+                "latitude": 1.0,
+                "longitude": 0,
+            },
+        ]
+
+        stats = generate_stats(resorts, {})
+
+        assert stats["with_valid_coordinates"] == 1
+
+    def test_coordinates_with_nonzero_longitude_only(self):
+        """A resort with longitude != 0 but latitude == 0 counts as valid."""
+        from handlers.version_consolidator import generate_stats
+
+        resorts = [
+            {
+                "resort_id": "eq",
+                "name": "Meridian",
+                "country": "XX",
+                "region": "xx",
+                "latitude": 0,
+                "longitude": 1.0,
+            },
+        ]
+
+        stats = generate_stats(resorts, {})
+
+        assert stats["with_valid_coordinates"] == 1
+
+
+# ---------------------------------------------------------------------------
+# Tests for store_version
+# ---------------------------------------------------------------------------
+
+
+class TestStoreVersion:
+    """Tests for storing consolidated data and manifest to S3."""
+
+    @patch(f"{MODULE}.s3")
+    def test_stores_data_and_manifest(self, mock_s3):
+        from handlers.version_consolidator import store_version
+
+        resorts = [_make_resort_dict("whistler")]
+        manifest = {"version_id": "v20260203060000", "stats": {}}
+
+        data_key, manifest_key = store_version("20260203060000", resorts, manifest)
+
+        assert data_key == "resort-versions/data/v20260203060000/resorts.json"
+        assert manifest_key == "resort-versions/manifests/v20260203060000.json"
+        assert mock_s3.put_object.call_count == 2
+
+    @patch(f"{MODULE}.s3")
+    def test_data_key_format(self, mock_s3):
+        from handlers.version_consolidator import store_version
+
+        store_version("job123", [], {})
+
+        # First call is data, second is manifest
+        data_call = mock_s3.put_object.call_args_list[0]
+        assert data_call[1]["Key"] == "resort-versions/data/vjob123/resorts.json"
+        assert data_call[1]["ContentType"] == "application/json"
+
+    @patch(f"{MODULE}.s3")
+    def test_manifest_key_format(self, mock_s3):
+        from handlers.version_consolidator import store_version
+
+        store_version("job123", [], {})
+
+        manifest_call = mock_s3.put_object.call_args_list[1]
+        assert manifest_call[1]["Key"] == "resort-versions/manifests/vjob123.json"
+        assert manifest_call[1]["ContentType"] == "application/json"
+
+    @patch(f"{MODULE}.s3")
+    def test_data_body_contains_resorts(self, mock_s3):
+        from handlers.version_consolidator import store_version
+
+        resorts = [_make_resort_dict("whistler"), _make_resort_dict("vail")]
+        store_version("job123", resorts, {})
+
+        data_call = mock_s3.put_object.call_args_list[0]
+        body = json.loads(data_call[1]["Body"])
+        assert len(body["resorts"]) == 2
+
+    @patch(f"{MODULE}.s3")
+    def test_manifest_body_is_stored(self, mock_s3):
+        from handlers.version_consolidator import store_version
+
+        manifest = {"version_id": "vjob123", "status": "pending"}
+        store_version("job123", [], manifest)
+
+        manifest_call = mock_s3.put_object.call_args_list[1]
+        body = json.loads(manifest_call[1]["Body"])
+        assert body["version_id"] == "vjob123"
+        assert body["status"] == "pending"
+
+
+# ---------------------------------------------------------------------------
+# Tests for send_notification
+# ---------------------------------------------------------------------------
+
+
+class TestSendNotification:
+    """Tests for SNS notification sending."""
+
+    @patch(f"{MODULE}.RESORT_UPDATES_TOPIC_ARN", "arn:aws:sns:us-west-2:123:topic")
+    @patch(f"{MODULE}.sns")
+    def test_sends_notification(self, mock_sns):
+        from handlers.version_consolidator import send_notification
+
+        stats = {"total_resorts": 100}
+        diff = {
+            "added": [{"name": "New Resort", "country": "US"}],
+            "removed": [],
+            "modified": [{"resort_id": "x", "changes": ["name"]}],
+        }
+
+        send_notification("v20260203060000", stats, diff)
+
+        mock_sns.publish.assert_called_once()
+        call_kwargs = mock_sns.publish.call_args[1]
+        assert call_kwargs["TopicArn"] == "arn:aws:sns:us-west-2:123:topic"
+        assert "v20260203060000" in call_kwargs["Subject"]
+        assert "+1/-0" in call_kwargs["Subject"]
+
+    @patch(f"{MODULE}.RESORT_UPDATES_TOPIC_ARN", "")
+    @patch(f"{MODULE}.sns")
+    def test_skips_when_no_topic_arn(self, mock_sns):
+        from handlers.version_consolidator import send_notification
+
+        send_notification("v123", {}, {"added": [], "removed": [], "modified": []})
+
+        mock_sns.publish.assert_not_called()
+
+    @patch(f"{MODULE}.RESORT_UPDATES_TOPIC_ARN", "arn:aws:sns:us-west-2:123:topic")
+    @patch(f"{MODULE}.sns")
+    def test_handles_publish_error(self, mock_sns):
+        from handlers.version_consolidator import send_notification
+
+        mock_sns.publish.side_effect = RuntimeError("SNS error")
+        stats = {"total_resorts": 50}
+        diff = {"added": [], "removed": [], "modified": []}
+
+        # Should not raise
+        send_notification("v123", stats, diff)
+
+    @patch(f"{MODULE}.RESORT_UPDATES_TOPIC_ARN", "arn:aws:sns:us-west-2:123:topic")
+    @patch(f"{MODULE}.sns")
+    def test_message_contains_added_resorts(self, mock_sns):
+        from handlers.version_consolidator import send_notification
+
+        stats = {"total_resorts": 10}
+        diff = {
+            "added": [
+                {"name": "Resort A", "country": "US"},
+                {"name": "Resort B", "country": "CA"},
+            ],
+            "removed": [],
+            "modified": [],
+        }
+
+        send_notification("v123", stats, diff)
+
+        message = mock_sns.publish.call_args[1]["Message"]
+        assert "Resort A" in message
+        assert "Resort B" in message
+        assert "ADDED RESORTS" in message
+
+    @patch(f"{MODULE}.RESORT_UPDATES_TOPIC_ARN", "arn:aws:sns:us-west-2:123:topic")
+    @patch(f"{MODULE}.sns")
+    def test_message_contains_removed_resorts(self, mock_sns):
+        from handlers.version_consolidator import send_notification
+
+        stats = {"total_resorts": 10}
+        diff = {
+            "added": [],
+            "removed": [
+                {"name": "Old Resort", "country": "CH"},
+            ],
+            "modified": [],
+        }
+
+        send_notification("v123", stats, diff)
+
+        message = mock_sns.publish.call_args[1]["Message"]
+        assert "Old Resort" in message
+        assert "REMOVED RESORTS" in message
+
+    @patch(f"{MODULE}.RESORT_UPDATES_TOPIC_ARN", "arn:aws:sns:us-west-2:123:topic")
+    @patch(f"{MODULE}.sns")
+    def test_message_truncates_long_lists(self, mock_sns):
+        from handlers.version_consolidator import send_notification
+
+        stats = {"total_resorts": 30}
+        added = [{"name": f"Resort {i}", "country": "US"} for i in range(25)]
+        diff = {"added": added, "removed": [], "modified": []}
+
+        send_notification("v123", stats, diff)
+
+        message = mock_sns.publish.call_args[1]["Message"]
+        assert "... and 5 more" in message
+
+    @patch(f"{MODULE}.RESORT_UPDATES_TOPIC_ARN", "arn:aws:sns:us-west-2:123:topic")
+    @patch(f"{MODULE}.sns")
+    def test_subject_truncated_to_100_chars(self, mock_sns):
+        from handlers.version_consolidator import send_notification
+
+        stats = {"total_resorts": 10}
+        diff = {"added": [], "removed": [], "modified": []}
+
+        send_notification("v123", stats, diff)
+
+        subject = mock_sns.publish.call_args[1]["Subject"]
+        assert len(subject) <= 100
+
+    @patch(f"{MODULE}.RESORT_UPDATES_TOPIC_ARN", "arn:aws:sns:us-west-2:123:topic")
+    @patch(f"{MODULE}.sns")
+    def test_message_contains_deploy_instructions(self, mock_sns):
+        from handlers.version_consolidator import send_notification
+
+        stats = {"total_resorts": 10}
+        diff = {"added": [], "removed": [], "modified": []}
+
+        send_notification("v123", stats, diff)
+
+        message = mock_sns.publish.call_args[1]["Message"]
+        assert "To deploy this version:" in message
+        assert "gh workflow run" in message
+
+
+# ---------------------------------------------------------------------------
+# Tests for version_consolidator_handler (Lambda entry point)
+# ---------------------------------------------------------------------------
+
+
+class TestVersionConsolidatorHandler:
+    """Tests for the main Lambda handler function."""
+
+    @patch(f"{MODULE}.send_notification")
+    @patch(f"{MODULE}.store_version")
+    @patch(f"{MODULE}.get_production_resorts")
+    @patch(f"{MODULE}.get_scraper_results")
+    def test_success_with_explicit_job_id(
+        self, mock_get_results, mock_get_prod, mock_store, mock_notify
+    ):
+        from handlers.version_consolidator import version_consolidator_handler
+
+        resorts = [
+            _make_resort_dict("whistler", "Whistler", "CA", "na_west"),
+            _make_resort_dict("vail", "Vail", "US", "na_rockies"),
+        ]
+        mock_get_results.return_value = (
+            resorts,
+            {"CA": {"count": 1}, "US": {"count": 1}},
+        )
+        mock_get_prod.return_value = {}
+        mock_store.return_value = (
+            "resort-versions/data/vjob123/resorts.json",
+            "resort-versions/manifests/vjob123.json",
+        )
+
+        result = version_consolidator_handler(
+            {"job_id": "job123"}, _make_lambda_context()
+        )
+
+        assert result["statusCode"] == 200
+        body = json.loads(result["body"])
+        assert body["version_id"] == "vjob123"
+        assert body["total_resorts"] == 2
+        assert body["added"] == 2
+        assert body["removed"] == 0
+        mock_store.assert_called_once()
+        mock_notify.assert_called_once()
+
+    @patch(f"{MODULE}.send_notification")
+    @patch(f"{MODULE}.store_version")
+    @patch(f"{MODULE}.get_production_resorts")
+    @patch(f"{MODULE}.get_scraper_results")
+    @patch(f"{MODULE}.get_latest_scraper_job_id")
+    def test_success_with_latest_job(
+        self, mock_get_latest, mock_get_results, mock_get_prod, mock_store, mock_notify
+    ):
+        from handlers.version_consolidator import version_consolidator_handler
+
+        mock_get_latest.return_value = "20260203060000"
+        resorts = [_make_resort_dict("whistler")]
+        mock_get_results.return_value = (resorts, {"CA": {"count": 1}})
+        mock_get_prod.return_value = {}
+        mock_store.return_value = ("data_key", "manifest_key")
+
+        result = version_consolidator_handler({}, _make_lambda_context())
+
+        assert result["statusCode"] == 200
+        body = json.loads(result["body"])
+        assert body["version_id"] == "v20260203060000"
+        mock_get_latest.assert_called_once()
+
+    @patch(f"{MODULE}.get_latest_scraper_job_id")
+    def test_no_job_id_and_no_latest(self, mock_get_latest):
+        from handlers.version_consolidator import version_consolidator_handler
+
+        mock_get_latest.return_value = None
+
+        result = version_consolidator_handler({}, _make_lambda_context())
+
+        assert result["statusCode"] == 400
+        body = json.loads(result["body"])
+        assert "error" in body
+
+    @patch(f"{MODULE}.get_scraper_results")
+    def test_no_resorts_found(self, mock_get_results):
+        from handlers.version_consolidator import version_consolidator_handler
+
+        mock_get_results.return_value = ([], {})
+
+        result = version_consolidator_handler(
+            {"job_id": "job123"}, _make_lambda_context()
+        )
+
+        assert result["statusCode"] == 404
+        body = json.loads(result["body"])
+        assert "No resorts found" in body["error"]
+
+    @patch(f"{MODULE}.get_latest_scraper_job_id")
+    def test_no_job_id_with_process_latest_false(self, mock_get_latest):
+        from handlers.version_consolidator import version_consolidator_handler
+
+        result = version_consolidator_handler(
+            {"process_latest": False}, _make_lambda_context()
+        )
+
+        assert result["statusCode"] == 400
+        mock_get_latest.assert_not_called()
+
+    @patch(f"{MODULE}.send_notification")
+    @patch(f"{MODULE}.store_version")
+    @patch(f"{MODULE}.get_production_resorts")
+    @patch(f"{MODULE}.get_scraper_results")
+    def test_response_includes_duration(
+        self, mock_get_results, mock_get_prod, mock_store, mock_notify
+    ):
+        from handlers.version_consolidator import version_consolidator_handler
+
+        resorts = [_make_resort_dict("whistler")]
+        mock_get_results.return_value = (resorts, {})
+        mock_get_prod.return_value = {}
+        mock_store.return_value = ("data_key", "manifest_key")
+
+        result = version_consolidator_handler(
+            {"job_id": "job123"}, _make_lambda_context()
+        )
+
+        body = json.loads(result["body"])
+        assert "duration_seconds" in body
+        assert body["duration_seconds"] >= 0
+
+    @patch(f"{MODULE}.send_notification")
+    @patch(f"{MODULE}.store_version")
+    @patch(f"{MODULE}.get_production_resorts")
+    @patch(f"{MODULE}.get_scraper_results")
+    def test_manifest_structure(
+        self, mock_get_results, mock_get_prod, mock_store, mock_notify
+    ):
+        from handlers.version_consolidator import version_consolidator_handler
+
+        resorts = [_make_resort_dict("whistler")]
+        mock_get_results.return_value = (resorts, {"CA": {"count": 1}})
+        mock_get_prod.return_value = {
+            "vail": _make_production_resort("vail", "Vail"),
+        }
+        mock_store.return_value = ("data_key", "manifest_key")
+
+        version_consolidator_handler({"job_id": "job123"}, _make_lambda_context())
+
+        # Verify manifest passed to store_version
+        call_args = mock_store.call_args
+        manifest = call_args[0][2]  # third positional arg
+
+        assert manifest["version_id"] == "vjob123"
+        assert manifest["job_id"] == "job123"
+        assert manifest["status"] == "pending"
+        assert manifest["deployment_history"] == []
+        assert "created_at" in manifest
+        assert "stats" in manifest
+        assert "diff" in manifest
+        assert manifest["stats"]["total_resorts"] == 1
+
+    @patch(f"{MODULE}.send_notification")
+    @patch(f"{MODULE}.store_version")
+    @patch(f"{MODULE}.get_production_resorts")
+    @patch(f"{MODULE}.get_scraper_results")
+    def test_diff_passed_to_notification(
+        self, mock_get_results, mock_get_prod, mock_store, mock_notify
+    ):
+        from handlers.version_consolidator import version_consolidator_handler
+
+        resorts = [_make_resort_dict("whistler")]
+        mock_get_results.return_value = (resorts, {})
+        mock_get_prod.return_value = {}
+        mock_store.return_value = ("data_key", "manifest_key")
+
+        version_consolidator_handler({"job_id": "job123"}, _make_lambda_context())
+
+        # Verify notification was called with version_id, stats, and diff
+        notify_args = mock_notify.call_args[0]
+        assert notify_args[0] == "vjob123"  # version_id
+        assert notify_args[1]["total_resorts"] == 1  # stats
+        assert len(notify_args[2]["added"]) == 1  # diff
+
+    @patch(f"{MODULE}.send_notification")
+    @patch(f"{MODULE}.store_version")
+    @patch(f"{MODULE}.get_production_resorts")
+    @patch(f"{MODULE}.get_scraper_results")
+    def test_response_body_fields(
+        self, mock_get_results, mock_get_prod, mock_store, mock_notify
+    ):
+        from handlers.version_consolidator import version_consolidator_handler
+
+        new_resorts = [
+            _make_resort_dict("whistler", "Whistler"),
+            _make_resort_dict("zermatt", "Zermatt", "CH", "alps"),
+        ]
+        mock_get_results.return_value = (new_resorts, {})
+        mock_get_prod.return_value = {
+            "whistler": _make_production_resort("whistler", "Whistler Updated"),
+            "vail": _make_production_resort("vail", "Vail"),
+        }
+        mock_store.return_value = ("data_key", "manifest_key")
+
+        result = version_consolidator_handler(
+            {"job_id": "job123"}, _make_lambda_context()
+        )
+
+        body = json.loads(result["body"])
+        assert body["message"] == "Created version vjob123"
+        assert body["version_id"] == "vjob123"
+        assert body["total_resorts"] == 2
+        assert body["added"] == 1  # zermatt
+        assert body["removed"] == 1  # vail
+        assert body["modified"] == 1  # whistler (name change)
+        assert body["data_key"] == "data_key"
+        assert body["manifest_key"] == "manifest_key"
+
+    @patch(f"{MODULE}.send_notification")
+    @patch(f"{MODULE}.store_version")
+    @patch(f"{MODULE}.get_production_resorts")
+    @patch(f"{MODULE}.get_scraper_results")
+    def test_environment_in_manifest(
+        self, mock_get_results, mock_get_prod, mock_store, mock_notify
+    ):
+        from handlers.version_consolidator import version_consolidator_handler
+
+        resorts = [_make_resort_dict("whistler")]
+        mock_get_results.return_value = (resorts, {})
+        mock_get_prod.return_value = {}
+        mock_store.return_value = ("data_key", "manifest_key")
+
+        with patch(f"{MODULE}.ENVIRONMENT", "staging"):
+            version_consolidator_handler({"job_id": "job123"}, _make_lambda_context())
+
+        manifest = mock_store.call_args[0][2]
+        assert manifest["environment"] == "staging"

--- a/backend/tests/test_weather_worker.py
+++ b/backend/tests/test_weather_worker.py
@@ -1,0 +1,1668 @@
+"""Tests for the weather worker Lambda handler.
+
+Tests cover:
+- save_weather_condition: DynamoDB writes, error handling
+- process_elevation_point: dict and object elevation points, scraper merging,
+  snow summary updates (freeze events, delta tracking, openmeteo accumulation),
+  snowfall window consistency, quality attributes, error handling
+- weather_worker_handler: full Lambda handler flow, batch DynamoDB fetches,
+  parallel processing, rate limiting, scraper integration, error handling,
+  empty inputs, statistics tracking
+"""
+
+import json
+from datetime import UTC, datetime
+from types import SimpleNamespace
+from unittest.mock import MagicMock, Mock, call, patch
+
+import pytest
+from botocore.exceptions import ClientError
+
+from models.weather import ConfidenceLevel, SnowQuality, WeatherCondition
+
+# ---------------------------------------------------------------------------
+# Module path for patching
+# ---------------------------------------------------------------------------
+MODULE = "handlers.weather_worker"
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_weather_data(**overrides):
+    """Return a plausible weather-data dict as returned by OpenMeteoService."""
+    defaults = {
+        "current_temp_celsius": -5.0,
+        "min_temp_celsius": -8.0,
+        "max_temp_celsius": -2.0,
+        "snowfall_24h_cm": 10.0,
+        "snowfall_48h_cm": 15.0,
+        "snowfall_72h_cm": 20.0,
+        "hours_above_ice_threshold": 0.0,
+        "max_consecutive_warm_hours": 0.0,
+        "snowfall_after_freeze_cm": 10.0,
+        "hours_since_last_snowfall": 2.0,
+        "last_freeze_thaw_hours_ago": 72.0,
+        "currently_warming": False,
+        "humidity_percent": 80.0,
+        "wind_speed_kmh": 12.0,
+        "weather_description": "Light snow",
+        "data_source": "open-meteo",
+        "source_confidence": "high",
+        "snow_depth_cm": 120.0,
+    }
+    defaults.update(overrides)
+    return defaults
+
+
+def _make_elevation_point_obj(level="mid", lat=49.72, lon=-118.93, elev=1800):
+    """Create a minimal elevation-point-like object (non-dict)."""
+    return SimpleNamespace(
+        level=SimpleNamespace(value=level),
+        latitude=lat,
+        longitude=lon,
+        elevation_meters=elev,
+    )
+
+
+def _make_elevation_point_dict(level="mid", lat=49.72, lon=-118.93, elev=1800):
+    """Create a dict-format elevation point (as stored in DynamoDB)."""
+    return {
+        "latitude": lat,
+        "longitude": lon,
+        "elevation_meters": elev,
+        "level": level,
+    }
+
+
+def _make_resort_data(
+    resort_id="big-white",
+    name="Big White",
+    elevation_points=None,
+):
+    """Create a resort data dict as returned from DynamoDB batch_get_item."""
+    if elevation_points is None:
+        elevation_points = [
+            _make_elevation_point_dict("base", elev=1508),
+            _make_elevation_point_dict("mid", elev=1800),
+            _make_elevation_point_dict("top", elev=2319),
+        ]
+    return {
+        "resort_id": resort_id,
+        "name": name,
+        "elevation_points": elevation_points,
+    }
+
+
+def _make_condition():
+    """Create a minimal WeatherCondition for testing."""
+    return WeatherCondition(
+        resort_id="big-white",
+        elevation_level="mid",
+        timestamp=datetime.now(UTC).isoformat(),
+        current_temp_celsius=-5.0,
+        min_temp_celsius=-8.0,
+        max_temp_celsius=-2.0,
+        data_source="open-meteo",
+        source_confidence=ConfidenceLevel.HIGH,
+    )
+
+
+def _make_lambda_context():
+    """Create a mock Lambda context object."""
+    ctx = SimpleNamespace()
+    ctx.get_remaining_time_in_millis = lambda: 300000
+    return ctx
+
+
+def _default_summary(freeze_date="2026-02-15"):
+    """Create a default snow summary dict."""
+    return {
+        "last_freeze_date": freeze_date,
+        "snowfall_since_freeze_cm": 5.0,
+        "total_season_snowfall_cm": 100.0,
+        "season_start_date": "2025-11-15",
+        "last_snowfall_24h_cm": 3.0,
+    }
+
+
+def _setup_services(weather_data=None, quality_result=None, existing_summary=None):
+    """Set up mock services with defaults."""
+    weather_service = MagicMock()
+    weather_service.get_current_weather.return_value = (
+        weather_data or _make_weather_data()
+    )
+
+    snow_quality_service = MagicMock()
+    snow_quality_service.assess_snow_quality.return_value = quality_result or (
+        SnowQuality.GOOD,
+        12.0,
+        ConfidenceLevel.HIGH,
+        4.5,
+    )
+
+    table = MagicMock()
+    table.put_item.return_value = {}
+
+    snow_summary_service = MagicMock()
+    snow_summary_service.get_or_create_summary.return_value = (
+        existing_summary or _default_summary()
+    )
+
+    return weather_service, snow_quality_service, table, snow_summary_service
+
+
+# ---------------------------------------------------------------------------
+# Tests for save_weather_condition
+# ---------------------------------------------------------------------------
+
+
+class TestSaveWeatherCondition:
+    """Tests for saving a weather condition to DynamoDB."""
+
+    def test_save_success(self):
+        from handlers.weather_worker import save_weather_condition
+
+        table = MagicMock()
+        table.put_item.return_value = {}
+        condition = _make_condition()
+
+        save_weather_condition(table, condition)
+
+        table.put_item.assert_called_once()
+        item = table.put_item.call_args[1]["Item"]
+        assert item["resort_id"] is not None
+
+    def test_save_calls_prepare_for_dynamodb(self):
+        """Verify that prepare_for_dynamodb is called before put_item."""
+        from handlers.weather_worker import save_weather_condition
+
+        table = MagicMock()
+        table.put_item.return_value = {}
+        condition = _make_condition()
+
+        with patch(f"{MODULE}.prepare_for_dynamodb", wraps=lambda x: x) as mock_prep:
+            save_weather_condition(table, condition)
+            mock_prep.assert_called_once()
+
+    def test_save_client_error_raises(self):
+        from handlers.weather_worker import save_weather_condition
+
+        table = MagicMock()
+        table.put_item.side_effect = ClientError(
+            {
+                "Error": {
+                    "Code": "ProvisionedThroughputExceededException",
+                    "Message": "Rate exceeded",
+                }
+            },
+            "PutItem",
+        )
+        condition = _make_condition()
+
+        with pytest.raises(ClientError):
+            save_weather_condition(table, condition)
+
+    def test_save_unexpected_error_raises(self):
+        from handlers.weather_worker import save_weather_condition
+
+        table = MagicMock()
+        table.put_item.side_effect = ValueError("unexpected")
+        condition = _make_condition()
+
+        with pytest.raises(ValueError):
+            save_weather_condition(table, condition)
+
+
+# ---------------------------------------------------------------------------
+# Tests for process_elevation_point
+# ---------------------------------------------------------------------------
+
+
+class TestProcessElevationPoint:
+    """Tests for processing a single elevation point."""
+
+    def test_success_with_dict_elevation_point(self):
+        """Dict-format elevation points (from DynamoDB) should work."""
+        from handlers.weather_worker import process_elevation_point
+
+        ws, sqs, table, sss = _setup_services()
+        ep = _make_elevation_point_dict("mid")
+
+        result = process_elevation_point(
+            elevation_point=ep,
+            resort_id="big-white",
+            weather_service=ws,
+            snow_quality_service=sqs,
+            weather_conditions_table=table,
+            scraper=None,
+            scraped_data=None,
+            snow_summary_service=sss,
+        )
+
+        assert result["success"] is True
+        assert result["error"] is None
+        assert result["level"] == "mid"
+        table.put_item.assert_called_once()
+
+    def test_success_with_object_elevation_point(self):
+        """Object-format elevation points with .level.value should work."""
+        from handlers.weather_worker import process_elevation_point
+
+        ws, sqs, table, sss = _setup_services()
+        ep = _make_elevation_point_obj("top")
+
+        result = process_elevation_point(
+            elevation_point=ep,
+            resort_id="big-white",
+            weather_service=ws,
+            snow_quality_service=sqs,
+            weather_conditions_table=table,
+            scraper=None,
+            scraped_data=None,
+            snow_summary_service=sss,
+        )
+
+        assert result["success"] is True
+        assert result["level"] == "top"
+
+    def test_object_level_plain_string(self):
+        """When elevation_point.level is a plain string (no .value)."""
+        from handlers.weather_worker import process_elevation_point
+
+        ws, sqs, table, sss = _setup_services()
+        ep = SimpleNamespace(
+            level="base",
+            latitude=49.72,
+            longitude=-118.93,
+            elevation_meters=1508,
+        )
+
+        result = process_elevation_point(
+            elevation_point=ep,
+            resort_id="big-white",
+            weather_service=ws,
+            snow_quality_service=sqs,
+            weather_conditions_table=table,
+            scraper=None,
+            scraped_data=None,
+            snow_summary_service=sss,
+        )
+
+        assert result["success"] is True
+        assert result["level"] == "base"
+
+    def test_without_scraper(self):
+        from handlers.weather_worker import process_elevation_point
+
+        ws, sqs, table, sss = _setup_services()
+        ep = _make_elevation_point_dict("base")
+
+        result = process_elevation_point(
+            elevation_point=ep,
+            resort_id="test-resort",
+            weather_service=ws,
+            snow_quality_service=sqs,
+            weather_conditions_table=table,
+            scraper=None,
+            scraped_data=None,
+            snow_summary_service=sss,
+        )
+
+        assert result["success"] is True
+        ws.get_current_weather.assert_called_once()
+
+    def test_with_scraper_data(self):
+        from handlers.weather_worker import process_elevation_point
+
+        ws, sqs, table, sss = _setup_services()
+        ep = _make_elevation_point_dict("top")
+
+        scraper = MagicMock()
+        scraped_data = SimpleNamespace(snowfall_24h_cm=20.0, snowfall_48h_cm=30.0)
+        merged_data = _make_weather_data(snowfall_24h_cm=20.0)
+        scraper.merge_with_weather_data.return_value = merged_data
+
+        result = process_elevation_point(
+            elevation_point=ep,
+            resort_id="test-resort",
+            weather_service=ws,
+            snow_quality_service=sqs,
+            weather_conditions_table=table,
+            scraper=scraper,
+            scraped_data=scraped_data,
+            snow_summary_service=sss,
+        )
+
+        assert result["success"] is True
+        scraper.merge_with_weather_data.assert_called_once()
+
+    def test_scraper_not_called_without_scraped_data(self):
+        """If scraped_data is None, scraper.merge should not be called."""
+        from handlers.weather_worker import process_elevation_point
+
+        ws, sqs, table, sss = _setup_services()
+        ep = _make_elevation_point_dict("mid")
+        scraper = MagicMock()
+
+        result = process_elevation_point(
+            elevation_point=ep,
+            resort_id="test-resort",
+            weather_service=ws,
+            snow_quality_service=sqs,
+            weather_conditions_table=table,
+            scraper=scraper,
+            scraped_data=None,
+            snow_summary_service=sss,
+        )
+
+        assert result["success"] is True
+        scraper.merge_with_weather_data.assert_not_called()
+
+    def test_without_snow_summary_service(self):
+        from handlers.weather_worker import process_elevation_point
+
+        ws, sqs, table, _ = _setup_services()
+        ep = _make_elevation_point_dict("mid")
+
+        result = process_elevation_point(
+            elevation_point=ep,
+            resort_id="big-white",
+            weather_service=ws,
+            snow_quality_service=sqs,
+            weather_conditions_table=table,
+            scraper=None,
+            scraped_data=None,
+            snow_summary_service=None,
+        )
+
+        assert result["success"] is True
+
+    def test_freeze_event_detected(self):
+        """When a new freeze event is detected, record_freeze_event should be called."""
+        from handlers.weather_worker import process_elevation_point
+
+        weather_data = _make_weather_data(
+            freeze_event_detected=True,
+            detected_freeze_date="2026-02-20T12:00",
+            snowfall_after_freeze_cm=5.0,
+        )
+        ws, sqs, table, sss = _setup_services(weather_data=weather_data)
+        ep = _make_elevation_point_dict("mid")
+
+        result = process_elevation_point(
+            elevation_point=ep,
+            resort_id="big-white",
+            weather_service=ws,
+            snow_quality_service=sqs,
+            weather_conditions_table=table,
+            scraper=None,
+            scraped_data=None,
+            snow_summary_service=sss,
+        )
+
+        assert result["success"] is True
+        sss.record_freeze_event.assert_called_once_with(
+            resort_id="big-white",
+            elevation_level="mid",
+            freeze_date="2026-02-20T12:00",
+        )
+        sss.update_summary.assert_called_once()
+
+    def test_freeze_event_updates_season_totals(self):
+        """Freeze event update should accumulate total_season_snowfall."""
+        from handlers.weather_worker import process_elevation_point
+
+        weather_data = _make_weather_data(
+            freeze_event_detected=True,
+            detected_freeze_date="2026-02-20",
+            snowfall_after_freeze_cm=5.0,
+            snowfall_24h_cm=8.0,
+        )
+        existing_summary = _default_summary()
+        existing_summary["total_season_snowfall_cm"] = 200.0
+        ws, sqs, table, sss = _setup_services(
+            weather_data=weather_data, existing_summary=existing_summary
+        )
+        ep = _make_elevation_point_dict("mid")
+
+        process_elevation_point(
+            elevation_point=ep,
+            resort_id="big-white",
+            weather_service=ws,
+            snow_quality_service=sqs,
+            weather_conditions_table=table,
+            scraper=None,
+            scraped_data=None,
+            snow_summary_service=sss,
+        )
+
+        call_kwargs = sss.update_summary.call_args[1]
+        assert call_kwargs["snowfall_since_freeze_cm"] == 5.0
+        assert call_kwargs["total_season_snowfall_cm"] == 208.0  # 200 + 8
+
+    def test_no_freeze_openmeteo_can_see_freeze(self):
+        """When last_freeze_thaw_hours_ago < 336, use Open-Meteo accumulation."""
+        from handlers.weather_worker import process_elevation_point
+
+        weather_data = _make_weather_data(
+            freeze_event_detected=False,
+            snowfall_after_freeze_cm=15.0,
+            last_freeze_thaw_hours_ago=100,
+        )
+        existing_summary = {
+            "last_freeze_date": "2026-02-10",
+            "snowfall_since_freeze_cm": 10.0,
+            "total_season_snowfall_cm": 200.0,
+            "season_start_date": "2025-11-15",
+            "last_snowfall_24h_cm": 3.0,
+        }
+        ws, sqs, table, sss = _setup_services(
+            weather_data=weather_data, existing_summary=existing_summary
+        )
+        ep = _make_elevation_point_dict("mid")
+
+        result = process_elevation_point(
+            elevation_point=ep,
+            resort_id="big-white",
+            weather_service=ws,
+            snow_quality_service=sqs,
+            weather_conditions_table=table,
+            scraper=None,
+            scraped_data=None,
+            snow_summary_service=sss,
+        )
+
+        assert result["success"] is True
+        sss.record_freeze_event.assert_not_called()
+        sss.update_summary.assert_called_once()
+        call_kwargs = sss.update_summary.call_args[1]
+        # Uses openmeteo accumulation directly
+        assert call_kwargs["snowfall_since_freeze_cm"] == 15.0
+        # total_season adds the delta: 200 + max(0, 15 - 10) = 205
+        assert call_kwargs["total_season_snowfall_cm"] == 205.0
+
+    def test_no_freeze_older_than_14_days_delta_tracking(self):
+        """When freeze > 336h, use delta tracking based on 24h snowfall change."""
+        from handlers.weather_worker import process_elevation_point
+
+        weather_data = _make_weather_data(
+            freeze_event_detected=False,
+            snowfall_after_freeze_cm=8.0,
+            last_freeze_thaw_hours_ago=400,  # > 336 hours
+            snowfall_24h_cm=5.0,
+        )
+        existing_summary = {
+            "last_freeze_date": "2026-02-01",
+            "snowfall_since_freeze_cm": 20.0,
+            "total_season_snowfall_cm": 200.0,
+            "season_start_date": "2025-11-15",
+            "last_snowfall_24h_cm": 3.0,
+        }
+        ws, sqs, table, sss = _setup_services(
+            weather_data=weather_data, existing_summary=existing_summary
+        )
+        ep = _make_elevation_point_dict("top")
+
+        result = process_elevation_point(
+            elevation_point=ep,
+            resort_id="big-white",
+            weather_service=ws,
+            snow_quality_service=sqs,
+            weather_conditions_table=table,
+            scraper=None,
+            scraped_data=None,
+            snow_summary_service=sss,
+        )
+
+        assert result["success"] is True
+        sss.update_summary.assert_called_once()
+        call_kwargs = sss.update_summary.call_args[1]
+        # delta = max(0, 5.0 - 3.0) = 2.0
+        # new accumulation = 20.0 + 2.0 = 22.0
+        assert call_kwargs["snowfall_since_freeze_cm"] == 22.0
+        # total = 200 + 2.0 = 202.0
+        assert call_kwargs["total_season_snowfall_cm"] == 202.0
+        assert call_kwargs["last_snowfall_24h_cm"] == 5.0
+
+    def test_no_freeze_older_than_14_days_negative_delta_clamped(self):
+        """Negative delta (24h dropped) should be clamped to 0."""
+        from handlers.weather_worker import process_elevation_point
+
+        weather_data = _make_weather_data(
+            freeze_event_detected=False,
+            snowfall_after_freeze_cm=8.0,
+            last_freeze_thaw_hours_ago=400,
+            snowfall_24h_cm=2.0,  # Less than previous 3.0
+        )
+        existing_summary = {
+            "last_freeze_date": "2026-02-01",
+            "snowfall_since_freeze_cm": 20.0,
+            "total_season_snowfall_cm": 200.0,
+            "season_start_date": "2025-11-15",
+            "last_snowfall_24h_cm": 3.0,
+        }
+        ws, sqs, table, sss = _setup_services(
+            weather_data=weather_data, existing_summary=existing_summary
+        )
+        ep = _make_elevation_point_dict("mid")
+
+        process_elevation_point(
+            elevation_point=ep,
+            resort_id="big-white",
+            weather_service=ws,
+            snow_quality_service=sqs,
+            weather_conditions_table=table,
+            scraper=None,
+            scraped_data=None,
+            snow_summary_service=sss,
+        )
+
+        call_kwargs = sss.update_summary.call_args[1]
+        # delta = max(0, 2.0 - 3.0) = 0.0
+        assert call_kwargs["snowfall_since_freeze_cm"] == 20.0  # unchanged
+        assert call_kwargs["total_season_snowfall_cm"] == 200.0  # unchanged
+
+    def test_no_freeze_uses_max_accumulation_for_weather_data(self):
+        """Weather data should use the higher of openmeteo vs existing accumulation."""
+        from handlers.weather_worker import process_elevation_point
+
+        weather_data = _make_weather_data(
+            freeze_event_detected=False,
+            snowfall_after_freeze_cm=5.0,
+            last_freeze_thaw_hours_ago=100,
+        )
+        existing_summary = {
+            "last_freeze_date": "2026-02-10",
+            "snowfall_since_freeze_cm": 12.0,  # Higher than openmeteo's 5.0
+            "total_season_snowfall_cm": 200.0,
+            "season_start_date": "2025-11-15",
+            "last_snowfall_24h_cm": 3.0,
+        }
+        ws, sqs, table, sss = _setup_services(
+            weather_data=weather_data, existing_summary=existing_summary
+        )
+        ep = _make_elevation_point_dict("mid")
+
+        process_elevation_point(
+            elevation_point=ep,
+            resort_id="big-white",
+            weather_service=ws,
+            snow_quality_service=sqs,
+            weather_conditions_table=table,
+            scraper=None,
+            scraped_data=None,
+            snow_summary_service=sss,
+        )
+
+        # The weather_data passed to WeatherCondition should have the higher value
+        # Check what was passed to assess_snow_quality
+        call_args = sqs.assess_snow_quality.call_args
+        condition = call_args[0][0]
+        assert condition.snowfall_after_freeze_cm == 12.0  # max(5.0, 12.0)
+
+    def test_snowfall_window_consistency_48h_fix(self):
+        """48h snowfall should be bumped up to match 24h if lower."""
+        from handlers.weather_worker import process_elevation_point
+
+        weather_data = _make_weather_data(
+            snowfall_24h_cm=15.0,
+            snowfall_48h_cm=10.0,  # inconsistent: less than 24h
+            snowfall_72h_cm=20.0,
+        )
+        ws, sqs, table, sss = _setup_services(weather_data=weather_data)
+        ep = _make_elevation_point_dict("mid")
+
+        process_elevation_point(
+            elevation_point=ep,
+            resort_id="big-white",
+            weather_service=ws,
+            snow_quality_service=sqs,
+            weather_conditions_table=table,
+            scraper=None,
+            scraped_data=None,
+            snow_summary_service=sss,
+        )
+
+        # The condition created should have consistent windows
+        condition = sqs.assess_snow_quality.call_args[0][0]
+        assert condition.snowfall_48h_cm >= condition.snowfall_24h_cm
+
+    def test_snowfall_window_consistency_72h_fix(self):
+        """72h snowfall should be bumped up to match 48h if lower."""
+        from handlers.weather_worker import process_elevation_point
+
+        weather_data = _make_weather_data(
+            snowfall_24h_cm=10.0,
+            snowfall_48h_cm=20.0,
+            snowfall_72h_cm=15.0,  # inconsistent: less than 48h
+        )
+        ws, sqs, table, sss = _setup_services(weather_data=weather_data)
+        ep = _make_elevation_point_dict("mid")
+
+        process_elevation_point(
+            elevation_point=ep,
+            resort_id="big-white",
+            weather_service=ws,
+            snow_quality_service=sqs,
+            weather_conditions_table=table,
+            scraper=None,
+            scraped_data=None,
+            snow_summary_service=sss,
+        )
+
+        condition = sqs.assess_snow_quality.call_args[0][0]
+        assert condition.snowfall_72h_cm >= condition.snowfall_48h_cm
+
+    def test_snowfall_window_both_inconsistent(self):
+        """Both 48h and 72h should be fixed when both are inconsistent."""
+        from handlers.weather_worker import process_elevation_point
+
+        weather_data = _make_weather_data(
+            snowfall_24h_cm=25.0,
+            snowfall_48h_cm=10.0,  # < 24h
+            snowfall_72h_cm=5.0,  # < 48h after fix
+        )
+        ws, sqs, table, sss = _setup_services(weather_data=weather_data)
+        ep = _make_elevation_point_dict("mid")
+
+        process_elevation_point(
+            elevation_point=ep,
+            resort_id="big-white",
+            weather_service=ws,
+            snow_quality_service=sqs,
+            weather_conditions_table=table,
+            scraper=None,
+            scraped_data=None,
+            snow_summary_service=sss,
+        )
+
+        condition = sqs.assess_snow_quality.call_args[0][0]
+        # After fixing: 48h = 25.0 (bumped to match 24h), 72h = 25.0 (bumped to match 48h)
+        assert condition.snowfall_48h_cm == 25.0
+        assert condition.snowfall_72h_cm == 25.0
+
+    def test_quality_attributes_set(self):
+        """The weather condition should carry quality assessment results."""
+        from handlers.weather_worker import process_elevation_point
+
+        quality_result = (SnowQuality.EXCELLENT, 15.0, ConfidenceLevel.VERY_HIGH, 5.5)
+        ws, sqs, table, sss = _setup_services(quality_result=quality_result)
+        ep = _make_elevation_point_dict("top")
+
+        result = process_elevation_point(
+            elevation_point=ep,
+            resort_id="big-white",
+            weather_service=ws,
+            snow_quality_service=sqs,
+            weather_conditions_table=table,
+            scraper=None,
+            scraped_data=None,
+            snow_summary_service=sss,
+        )
+
+        assert result["success"] is True
+        # Verify the condition saved to DynamoDB has quality attributes
+        saved_item = table.put_item.call_args[1]["Item"]
+        assert saved_item["snow_quality"] == SnowQuality.EXCELLENT.value
+        assert saved_item["fresh_snow_cm"] == 15.0
+        assert saved_item["confidence_level"] == ConfidenceLevel.VERY_HIGH.value
+        assert saved_item["quality_score"] == 5.5
+
+    def test_ttl_is_set(self):
+        """Weather condition should have a TTL set."""
+        from handlers.weather_worker import process_elevation_point
+
+        ws, sqs, table, sss = _setup_services()
+        ep = _make_elevation_point_dict("mid")
+
+        process_elevation_point(
+            elevation_point=ep,
+            resort_id="big-white",
+            weather_service=ws,
+            snow_quality_service=sqs,
+            weather_conditions_table=table,
+            scraper=None,
+            scraped_data=None,
+            snow_summary_service=sss,
+        )
+
+        saved_item = table.put_item.call_args[1]["Item"]
+        assert "ttl" in saved_item
+        # TTL should be approximately 60 days from now
+        expected_min = int(datetime.now(UTC).timestamp()) + 59 * 24 * 60 * 60
+        expected_max = int(datetime.now(UTC).timestamp()) + 61 * 24 * 60 * 60
+        assert expected_min <= saved_item["ttl"] <= expected_max
+
+    def test_error_in_weather_service(self):
+        from handlers.weather_worker import process_elevation_point
+
+        ws, sqs, table, sss = _setup_services()
+        ws.get_current_weather.side_effect = RuntimeError("API timeout")
+        ep = _make_elevation_point_dict("mid")
+
+        result = process_elevation_point(
+            elevation_point=ep,
+            resort_id="big-white",
+            weather_service=ws,
+            snow_quality_service=sqs,
+            weather_conditions_table=table,
+            scraper=None,
+            scraped_data=None,
+            snow_summary_service=sss,
+        )
+
+        assert result["success"] is False
+        assert "API timeout" in result["error"]
+
+    def test_error_in_dynamodb_save(self):
+        from handlers.weather_worker import process_elevation_point
+
+        ws, sqs, table, sss = _setup_services()
+        table.put_item.side_effect = ClientError(
+            {"Error": {"Code": "ValidationException", "Message": "Bad item"}},
+            "PutItem",
+        )
+        ep = _make_elevation_point_dict("mid")
+
+        result = process_elevation_point(
+            elevation_point=ep,
+            resort_id="big-white",
+            weather_service=ws,
+            snow_quality_service=sqs,
+            weather_conditions_table=table,
+            scraper=None,
+            scraped_data=None,
+            snow_summary_service=sss,
+        )
+
+        assert result["success"] is False
+        assert result["error"] is not None
+
+    def test_error_preserves_level(self):
+        """Even on error, the level should be captured from the elevation point."""
+        from handlers.weather_worker import process_elevation_point
+
+        ws, sqs, table, sss = _setup_services()
+        ws.get_current_weather.side_effect = RuntimeError("fail")
+        ep = _make_elevation_point_dict("top")
+
+        result = process_elevation_point(
+            elevation_point=ep,
+            resort_id="big-white",
+            weather_service=ws,
+            snow_quality_service=sqs,
+            weather_conditions_table=table,
+            scraper=None,
+            scraped_data=None,
+            snow_summary_service=sss,
+        )
+
+        assert result["success"] is False
+        assert result["level"] == "top"
+
+    def test_passes_last_known_freeze_date_to_weather_service(self):
+        """Weather service should receive the last_known_freeze_date from summary."""
+        from handlers.weather_worker import process_elevation_point
+
+        ws, sqs, table, sss = _setup_services()
+        ep = _make_elevation_point_dict("mid", lat=49.7, lon=-118.9, elev=1800)
+
+        process_elevation_point(
+            elevation_point=ep,
+            resort_id="big-white",
+            weather_service=ws,
+            snow_quality_service=sqs,
+            weather_conditions_table=table,
+            scraper=None,
+            scraped_data=None,
+            snow_summary_service=sss,
+        )
+
+        ws.get_current_weather.assert_called_once_with(
+            latitude=49.7,
+            longitude=-118.9,
+            elevation_meters=1800,
+            last_known_freeze_date="2026-02-15",
+        )
+
+    def test_elevation_passed_to_quality_service(self):
+        """Snow quality service should receive elevation_m for ML model."""
+        from handlers.weather_worker import process_elevation_point
+
+        ws, sqs, table, sss = _setup_services()
+        ep = _make_elevation_point_obj("mid", elev=2000)
+
+        process_elevation_point(
+            elevation_point=ep,
+            resort_id="big-white",
+            weather_service=ws,
+            snow_quality_service=sqs,
+            weather_conditions_table=table,
+            scraper=None,
+            scraped_data=None,
+            snow_summary_service=sss,
+        )
+
+        call_kwargs = sqs.assess_snow_quality.call_args[1]
+        assert call_kwargs["elevation_m"] == 2000
+
+
+# ---------------------------------------------------------------------------
+# Tests for weather_worker_handler
+# ---------------------------------------------------------------------------
+
+
+TABLE_NAME = "snow-tracker-resorts-dev"
+
+
+class TestWeatherWorkerHandler:
+    """Tests for the main Lambda handler."""
+
+    def _patch_all(self):
+        """Return a context manager that patches all handler dependencies."""
+        return (
+            patch(f"{MODULE}.dynamodb"),
+            patch(f"{MODULE}.OpenMeteoService"),
+            patch(f"{MODULE}.SnowQualityService"),
+            patch(f"{MODULE}.SnowSummaryService"),
+            patch(f"{MODULE}.OnTheSnowScraper"),
+            patch(f"{MODULE}.ENABLE_SCRAPING", False),
+            patch(f"{MODULE}.INTER_RESORT_DELAY", 0.0),
+            patch(f"{MODULE}.RESORTS_TABLE", TABLE_NAME),
+        )
+
+    def test_empty_resort_ids_returns_400(self):
+        from handlers.weather_worker import weather_worker_handler
+
+        result = weather_worker_handler({"resort_ids": []}, _make_lambda_context())
+
+        assert result["statusCode"] == 400
+        body = json.loads(result["body"])
+        assert "No resort_ids" in body["error"]
+
+    def test_missing_resort_ids_returns_400(self):
+        from handlers.weather_worker import weather_worker_handler
+
+        result = weather_worker_handler({}, _make_lambda_context())
+
+        assert result["statusCode"] == 400
+
+    def test_successful_single_resort_processing(self):
+        from handlers.weather_worker import weather_worker_handler
+
+        resort_data = _make_resort_data(
+            resort_id="big-white",
+            elevation_points=[_make_elevation_point_dict("mid")],
+        )
+
+        with (
+            patch(f"{MODULE}.dynamodb") as mock_ddb,
+            patch(f"{MODULE}.OpenMeteoService") as mock_ws_cls,
+            patch(f"{MODULE}.SnowQualityService") as mock_sqs_cls,
+            patch(f"{MODULE}.SnowSummaryService"),
+            patch(f"{MODULE}.OnTheSnowScraper"),
+            patch(f"{MODULE}.ENABLE_SCRAPING", False),
+            patch(f"{MODULE}.INTER_RESORT_DELAY", 0.0),
+            patch(f"{MODULE}.RESORTS_TABLE", TABLE_NAME),
+            patch(f"{MODULE}.process_elevation_point") as mock_pep,
+        ):
+            mock_ddb.meta.client.batch_get_item.return_value = {
+                "Responses": {TABLE_NAME: [resort_data]}
+            }
+            mock_pep.return_value = {
+                "success": True,
+                "error": None,
+                "level": "mid",
+            }
+
+            event = {"resort_ids": ["big-white"], "region": "na_west"}
+            result = weather_worker_handler(event, _make_lambda_context())
+
+        assert result["statusCode"] == 200
+        body = json.loads(result["body"])
+        assert body["stats"]["resorts_processed"] == 1
+        assert body["stats"]["conditions_saved"] == 1
+        assert body["stats"]["errors"] == 0
+
+    def test_multiple_resorts_processing(self):
+        from handlers.weather_worker import weather_worker_handler
+
+        resort1 = _make_resort_data(
+            "resort-1",
+            elevation_points=[_make_elevation_point_dict("mid")],
+        )
+        resort2 = _make_resort_data(
+            "resort-2",
+            elevation_points=[_make_elevation_point_dict("mid")],
+        )
+
+        with (
+            patch(f"{MODULE}.dynamodb") as mock_ddb,
+            patch(f"{MODULE}.OpenMeteoService"),
+            patch(f"{MODULE}.SnowQualityService"),
+            patch(f"{MODULE}.SnowSummaryService"),
+            patch(f"{MODULE}.OnTheSnowScraper"),
+            patch(f"{MODULE}.ENABLE_SCRAPING", False),
+            patch(f"{MODULE}.INTER_RESORT_DELAY", 0.0),
+            patch(f"{MODULE}.RESORTS_TABLE", TABLE_NAME),
+            patch(f"{MODULE}.process_elevation_point") as mock_pep,
+        ):
+            mock_ddb.meta.client.batch_get_item.return_value = {
+                "Responses": {TABLE_NAME: [resort1, resort2]}
+            }
+            mock_pep.return_value = {"success": True, "error": None, "level": "mid"}
+
+            event = {"resort_ids": ["resort-1", "resort-2"], "region": "na_west"}
+            result = weather_worker_handler(event, _make_lambda_context())
+
+        body = json.loads(result["body"])
+        assert body["stats"]["resorts_processed"] == 2
+        assert body["stats"]["conditions_saved"] == 2
+
+    def test_multiple_elevation_points(self):
+        """Each elevation point should be processed."""
+        from handlers.weather_worker import weather_worker_handler
+
+        resort = _make_resort_data(
+            "big-white",
+            elevation_points=[
+                _make_elevation_point_dict("base"),
+                _make_elevation_point_dict("mid"),
+                _make_elevation_point_dict("top"),
+            ],
+        )
+
+        with (
+            patch(f"{MODULE}.dynamodb") as mock_ddb,
+            patch(f"{MODULE}.OpenMeteoService"),
+            patch(f"{MODULE}.SnowQualityService"),
+            patch(f"{MODULE}.SnowSummaryService"),
+            patch(f"{MODULE}.OnTheSnowScraper"),
+            patch(f"{MODULE}.ENABLE_SCRAPING", False),
+            patch(f"{MODULE}.INTER_RESORT_DELAY", 0.0),
+            patch(f"{MODULE}.RESORTS_TABLE", TABLE_NAME),
+            patch(f"{MODULE}.process_elevation_point") as mock_pep,
+        ):
+            mock_ddb.meta.client.batch_get_item.return_value = {
+                "Responses": {TABLE_NAME: [resort]}
+            }
+            mock_pep.return_value = {"success": True, "error": None, "level": "mid"}
+
+            event = {"resort_ids": ["big-white"], "region": "na_west"}
+            result = weather_worker_handler(event, _make_lambda_context())
+
+        body = json.loads(result["body"])
+        assert body["stats"]["elevation_points_processed"] == 3
+        assert body["stats"]["conditions_saved"] == 3
+        assert mock_pep.call_count == 3
+
+    def test_resort_with_no_elevation_points(self):
+        """Resort with empty elevation_points should increment errors and skip."""
+        from handlers.weather_worker import weather_worker_handler
+
+        resort = _make_resort_data("empty-resort", elevation_points=[])
+
+        with (
+            patch(f"{MODULE}.dynamodb") as mock_ddb,
+            patch(f"{MODULE}.OpenMeteoService"),
+            patch(f"{MODULE}.SnowQualityService"),
+            patch(f"{MODULE}.SnowSummaryService"),
+            patch(f"{MODULE}.OnTheSnowScraper"),
+            patch(f"{MODULE}.ENABLE_SCRAPING", False),
+            patch(f"{MODULE}.INTER_RESORT_DELAY", 0.0),
+            patch(f"{MODULE}.RESORTS_TABLE", TABLE_NAME),
+            patch(f"{MODULE}.process_elevation_point") as mock_pep,
+        ):
+            mock_ddb.meta.client.batch_get_item.return_value = {
+                "Responses": {TABLE_NAME: [resort]}
+            }
+
+            event = {"resort_ids": ["empty-resort"], "region": "na_west"}
+            result = weather_worker_handler(event, _make_lambda_context())
+
+        body = json.loads(result["body"])
+        assert body["stats"]["errors"] == 1
+        assert body["stats"]["resorts_processed"] == 0
+        mock_pep.assert_not_called()
+
+    def test_elevation_point_failure_counted_as_error(self):
+        from handlers.weather_worker import weather_worker_handler
+
+        resort = _make_resort_data(
+            "test-resort",
+            elevation_points=[_make_elevation_point_dict("mid")],
+        )
+
+        with (
+            patch(f"{MODULE}.dynamodb") as mock_ddb,
+            patch(f"{MODULE}.OpenMeteoService"),
+            patch(f"{MODULE}.SnowQualityService"),
+            patch(f"{MODULE}.SnowSummaryService"),
+            patch(f"{MODULE}.OnTheSnowScraper"),
+            patch(f"{MODULE}.ENABLE_SCRAPING", False),
+            patch(f"{MODULE}.INTER_RESORT_DELAY", 0.0),
+            patch(f"{MODULE}.RESORTS_TABLE", TABLE_NAME),
+            patch(f"{MODULE}.process_elevation_point") as mock_pep,
+        ):
+            mock_ddb.meta.client.batch_get_item.return_value = {
+                "Responses": {TABLE_NAME: [resort]}
+            }
+            mock_pep.return_value = {
+                "success": False,
+                "error": "API failure",
+                "level": "mid",
+            }
+
+            event = {"resort_ids": ["test-resort"], "region": "na_west"}
+            result = weather_worker_handler(event, _make_lambda_context())
+
+        body = json.loads(result["body"])
+        assert body["stats"]["errors"] == 1
+        assert body["stats"]["conditions_saved"] == 0
+        # Resort is still counted as processed even with elevation errors
+        assert body["stats"]["resorts_processed"] == 1
+
+    def test_batch_get_item_pagination(self):
+        """Should handle more than 100 resort IDs by batching."""
+        from handlers.weather_worker import weather_worker_handler
+
+        resort_ids = [f"resort-{i}" for i in range(150)]
+        resort_batch1 = [
+            _make_resort_data(
+                f"resort-{i}", elevation_points=[_make_elevation_point_dict("mid")]
+            )
+            for i in range(100)
+        ]
+        resort_batch2 = [
+            _make_resort_data(
+                f"resort-{i}", elevation_points=[_make_elevation_point_dict("mid")]
+            )
+            for i in range(100, 150)
+        ]
+
+        with (
+            patch(f"{MODULE}.dynamodb") as mock_ddb,
+            patch(f"{MODULE}.OpenMeteoService"),
+            patch(f"{MODULE}.SnowQualityService"),
+            patch(f"{MODULE}.SnowSummaryService"),
+            patch(f"{MODULE}.OnTheSnowScraper"),
+            patch(f"{MODULE}.ENABLE_SCRAPING", False),
+            patch(f"{MODULE}.INTER_RESORT_DELAY", 0.0),
+            patch(f"{MODULE}.RESORTS_TABLE", TABLE_NAME),
+            patch(f"{MODULE}.process_elevation_point") as mock_pep,
+        ):
+            mock_ddb.meta.client.batch_get_item.side_effect = [
+                {"Responses": {TABLE_NAME: resort_batch1}},
+                {"Responses": {TABLE_NAME: resort_batch2}},
+            ]
+            mock_pep.return_value = {"success": True, "error": None, "level": "mid"}
+
+            event = {"resort_ids": resort_ids, "region": "na_west"}
+            result = weather_worker_handler(event, _make_lambda_context())
+
+        assert mock_ddb.meta.client.batch_get_item.call_count == 2
+        body = json.loads(result["body"])
+        assert body["stats"]["resorts_processed"] == 150
+
+    def test_scraper_enabled_hit(self):
+        """Scraper hit should be counted in stats."""
+        from handlers.weather_worker import weather_worker_handler
+
+        resort = _make_resort_data(
+            "big-white",
+            elevation_points=[_make_elevation_point_dict("mid")],
+        )
+
+        with (
+            patch(f"{MODULE}.dynamodb") as mock_ddb,
+            patch(f"{MODULE}.OpenMeteoService"),
+            patch(f"{MODULE}.SnowQualityService"),
+            patch(f"{MODULE}.SnowSummaryService"),
+            patch(f"{MODULE}.OnTheSnowScraper") as mock_scraper_cls,
+            patch(f"{MODULE}.ENABLE_SCRAPING", True),
+            patch(f"{MODULE}.INTER_RESORT_DELAY", 0.0),
+            patch(f"{MODULE}.RESORTS_TABLE", TABLE_NAME),
+            patch(f"{MODULE}.process_elevation_point") as mock_pep,
+        ):
+            mock_ddb.meta.client.batch_get_item.return_value = {
+                "Responses": {TABLE_NAME: [resort]}
+            }
+            scraper = mock_scraper_cls.return_value
+            scraper.is_resort_supported.return_value = True
+            scraper.get_snow_report.return_value = SimpleNamespace(snowfall_24h_cm=20.0)
+            mock_pep.return_value = {"success": True, "error": None, "level": "mid"}
+
+            event = {"resort_ids": ["big-white"], "region": "na_west"}
+            result = weather_worker_handler(event, _make_lambda_context())
+
+        body = json.loads(result["body"])
+        assert body["stats"]["scraper_hits"] == 1
+        assert body["stats"]["scraper_misses"] == 0
+
+    def test_scraper_miss(self):
+        """When scraper returns None, it should count as a miss."""
+        from handlers.weather_worker import weather_worker_handler
+
+        resort = _make_resort_data(
+            "big-white",
+            elevation_points=[_make_elevation_point_dict("mid")],
+        )
+
+        with (
+            patch(f"{MODULE}.dynamodb") as mock_ddb,
+            patch(f"{MODULE}.OpenMeteoService"),
+            patch(f"{MODULE}.SnowQualityService"),
+            patch(f"{MODULE}.SnowSummaryService"),
+            patch(f"{MODULE}.OnTheSnowScraper") as mock_scraper_cls,
+            patch(f"{MODULE}.ENABLE_SCRAPING", True),
+            patch(f"{MODULE}.INTER_RESORT_DELAY", 0.0),
+            patch(f"{MODULE}.RESORTS_TABLE", TABLE_NAME),
+            patch(f"{MODULE}.process_elevation_point") as mock_pep,
+        ):
+            mock_ddb.meta.client.batch_get_item.return_value = {
+                "Responses": {TABLE_NAME: [resort]}
+            }
+            scraper = mock_scraper_cls.return_value
+            scraper.is_resort_supported.return_value = True
+            scraper.get_snow_report.return_value = None
+            mock_pep.return_value = {"success": True, "error": None, "level": "mid"}
+
+            event = {"resort_ids": ["big-white"], "region": "na_west"}
+            result = weather_worker_handler(event, _make_lambda_context())
+
+        body = json.loads(result["body"])
+        assert body["stats"]["scraper_misses"] == 1
+
+    def test_scraper_exception_counted_as_miss(self):
+        from handlers.weather_worker import weather_worker_handler
+
+        resort = _make_resort_data(
+            "big-white",
+            elevation_points=[_make_elevation_point_dict("mid")],
+        )
+
+        with (
+            patch(f"{MODULE}.dynamodb") as mock_ddb,
+            patch(f"{MODULE}.OpenMeteoService"),
+            patch(f"{MODULE}.SnowQualityService"),
+            patch(f"{MODULE}.SnowSummaryService"),
+            patch(f"{MODULE}.OnTheSnowScraper") as mock_scraper_cls,
+            patch(f"{MODULE}.ENABLE_SCRAPING", True),
+            patch(f"{MODULE}.INTER_RESORT_DELAY", 0.0),
+            patch(f"{MODULE}.RESORTS_TABLE", TABLE_NAME),
+            patch(f"{MODULE}.process_elevation_point") as mock_pep,
+        ):
+            mock_ddb.meta.client.batch_get_item.return_value = {
+                "Responses": {TABLE_NAME: [resort]}
+            }
+            scraper = mock_scraper_cls.return_value
+            scraper.is_resort_supported.return_value = True
+            scraper.get_snow_report.side_effect = RuntimeError("Scrape error")
+            mock_pep.return_value = {"success": True, "error": None, "level": "mid"}
+
+            event = {"resort_ids": ["big-white"], "region": "na_west"}
+            result = weather_worker_handler(event, _make_lambda_context())
+
+        body = json.loads(result["body"])
+        assert body["stats"]["scraper_misses"] == 1
+
+    def test_scraper_disabled(self):
+        """When scraping is disabled, scraper should not be initialized."""
+        from handlers.weather_worker import weather_worker_handler
+
+        resort = _make_resort_data(
+            "big-white",
+            elevation_points=[_make_elevation_point_dict("mid")],
+        )
+
+        with (
+            patch(f"{MODULE}.dynamodb") as mock_ddb,
+            patch(f"{MODULE}.OpenMeteoService"),
+            patch(f"{MODULE}.SnowQualityService"),
+            patch(f"{MODULE}.SnowSummaryService"),
+            patch(f"{MODULE}.OnTheSnowScraper") as mock_scraper_cls,
+            patch(f"{MODULE}.ENABLE_SCRAPING", False),
+            patch(f"{MODULE}.INTER_RESORT_DELAY", 0.0),
+            patch(f"{MODULE}.RESORTS_TABLE", TABLE_NAME),
+            patch(f"{MODULE}.process_elevation_point") as mock_pep,
+        ):
+            mock_ddb.meta.client.batch_get_item.return_value = {
+                "Responses": {TABLE_NAME: [resort]}
+            }
+            mock_pep.return_value = {"success": True, "error": None, "level": "mid"}
+
+            event = {"resort_ids": ["big-white"], "region": "na_west"}
+            result = weather_worker_handler(event, _make_lambda_context())
+
+        mock_scraper_cls.assert_not_called()
+
+    def test_resort_not_supported_by_scraper(self):
+        """If scraper doesn't support the resort, scraping should be skipped."""
+        from handlers.weather_worker import weather_worker_handler
+
+        resort = _make_resort_data(
+            "chamonix",
+            elevation_points=[_make_elevation_point_dict("mid")],
+        )
+
+        with (
+            patch(f"{MODULE}.dynamodb") as mock_ddb,
+            patch(f"{MODULE}.OpenMeteoService"),
+            patch(f"{MODULE}.SnowQualityService"),
+            patch(f"{MODULE}.SnowSummaryService"),
+            patch(f"{MODULE}.OnTheSnowScraper") as mock_scraper_cls,
+            patch(f"{MODULE}.ENABLE_SCRAPING", True),
+            patch(f"{MODULE}.INTER_RESORT_DELAY", 0.0),
+            patch(f"{MODULE}.RESORTS_TABLE", TABLE_NAME),
+            patch(f"{MODULE}.process_elevation_point") as mock_pep,
+        ):
+            mock_ddb.meta.client.batch_get_item.return_value = {
+                "Responses": {TABLE_NAME: [resort]}
+            }
+            scraper = mock_scraper_cls.return_value
+            scraper.is_resort_supported.return_value = False
+            mock_pep.return_value = {"success": True, "error": None, "level": "mid"}
+
+            event = {"resort_ids": ["chamonix"], "region": "alps"}
+            result = weather_worker_handler(event, _make_lambda_context())
+
+        body = json.loads(result["body"])
+        scraper.get_snow_report.assert_not_called()
+        assert body["stats"]["scraper_hits"] == 0
+        assert body["stats"]["scraper_misses"] == 0
+
+    def test_resort_level_exception_caught(self):
+        """An exception during resort processing should be caught, not crash."""
+        from handlers.weather_worker import weather_worker_handler
+
+        resort = _make_resort_data(
+            "bad-resort",
+            elevation_points=[_make_elevation_point_dict("mid")],
+        )
+
+        with (
+            patch(f"{MODULE}.dynamodb") as mock_ddb,
+            patch(f"{MODULE}.OpenMeteoService"),
+            patch(f"{MODULE}.SnowQualityService"),
+            patch(f"{MODULE}.SnowSummaryService"),
+            patch(f"{MODULE}.OnTheSnowScraper"),
+            patch(f"{MODULE}.ENABLE_SCRAPING", False),
+            patch(f"{MODULE}.INTER_RESORT_DELAY", 0.0),
+            patch(f"{MODULE}.RESORTS_TABLE", TABLE_NAME),
+            patch(f"{MODULE}.ThreadPoolExecutor") as mock_tpe,
+        ):
+            mock_ddb.meta.client.batch_get_item.return_value = {
+                "Responses": {TABLE_NAME: [resort]}
+            }
+            mock_tpe.return_value.__enter__ = MagicMock(
+                side_effect=RuntimeError("Thread pool error")
+            )
+            mock_tpe.return_value.__exit__ = MagicMock(return_value=False)
+
+            event = {"resort_ids": ["bad-resort"], "region": "na_west"}
+            result = weather_worker_handler(event, _make_lambda_context())
+
+        assert result["statusCode"] == 200
+        body = json.loads(result["body"])
+        assert body["stats"]["errors"] >= 1
+
+    def test_fatal_error_returns_500(self):
+        """A fatal initialization error should return 500."""
+        from handlers.weather_worker import weather_worker_handler
+
+        with (
+            patch(f"{MODULE}.dynamodb") as mock_ddb,
+            patch(f"{MODULE}.OpenMeteoService") as mock_ws_cls,
+        ):
+            mock_ws_cls.side_effect = RuntimeError("Service init failed")
+
+            event = {"resort_ids": ["big-white"], "region": "na_west"}
+            result = weather_worker_handler(event, _make_lambda_context())
+
+        assert result["statusCode"] == 500
+        body = json.loads(result["body"])
+        assert "failed" in body["message"].lower()
+        assert "Service init failed" in body["error"]
+
+    def test_region_in_stats(self):
+        """Stats should contain the region from the event."""
+        from handlers.weather_worker import weather_worker_handler
+
+        resort = _make_resort_data(
+            "big-white",
+            elevation_points=[_make_elevation_point_dict("mid")],
+        )
+
+        with (
+            patch(f"{MODULE}.dynamodb") as mock_ddb,
+            patch(f"{MODULE}.OpenMeteoService"),
+            patch(f"{MODULE}.SnowQualityService"),
+            patch(f"{MODULE}.SnowSummaryService"),
+            patch(f"{MODULE}.OnTheSnowScraper"),
+            patch(f"{MODULE}.ENABLE_SCRAPING", False),
+            patch(f"{MODULE}.INTER_RESORT_DELAY", 0.0),
+            patch(f"{MODULE}.RESORTS_TABLE", TABLE_NAME),
+            patch(f"{MODULE}.process_elevation_point") as mock_pep,
+        ):
+            mock_ddb.meta.client.batch_get_item.return_value = {
+                "Responses": {TABLE_NAME: [resort]}
+            }
+            mock_pep.return_value = {"success": True, "error": None, "level": "mid"}
+
+            event = {"resort_ids": ["big-white"], "region": "alps"}
+            result = weather_worker_handler(event, _make_lambda_context())
+
+        body = json.loads(result["body"])
+        assert body["stats"]["region"] == "alps"
+
+    def test_default_region_unknown(self):
+        """When no region is provided, should default to 'unknown'."""
+        from handlers.weather_worker import weather_worker_handler
+
+        resort = _make_resort_data(
+            "big-white",
+            elevation_points=[_make_elevation_point_dict("mid")],
+        )
+
+        with (
+            patch(f"{MODULE}.dynamodb") as mock_ddb,
+            patch(f"{MODULE}.OpenMeteoService"),
+            patch(f"{MODULE}.SnowQualityService"),
+            patch(f"{MODULE}.SnowSummaryService"),
+            patch(f"{MODULE}.OnTheSnowScraper"),
+            patch(f"{MODULE}.ENABLE_SCRAPING", False),
+            patch(f"{MODULE}.INTER_RESORT_DELAY", 0.0),
+            patch(f"{MODULE}.RESORTS_TABLE", TABLE_NAME),
+            patch(f"{MODULE}.process_elevation_point") as mock_pep,
+        ):
+            mock_ddb.meta.client.batch_get_item.return_value = {
+                "Responses": {TABLE_NAME: [resort]}
+            }
+            mock_pep.return_value = {"success": True, "error": None, "level": "mid"}
+
+            event = {"resort_ids": ["big-white"]}
+            result = weather_worker_handler(event, _make_lambda_context())
+
+        body = json.loads(result["body"])
+        assert body["stats"]["region"] == "unknown"
+
+    def test_stats_contain_timing_info(self):
+        """Response should contain start_time, end_time, and duration_seconds."""
+        from handlers.weather_worker import weather_worker_handler
+
+        resort = _make_resort_data(
+            "big-white",
+            elevation_points=[_make_elevation_point_dict("mid")],
+        )
+
+        with (
+            patch(f"{MODULE}.dynamodb") as mock_ddb,
+            patch(f"{MODULE}.OpenMeteoService"),
+            patch(f"{MODULE}.SnowQualityService"),
+            patch(f"{MODULE}.SnowSummaryService"),
+            patch(f"{MODULE}.OnTheSnowScraper"),
+            patch(f"{MODULE}.ENABLE_SCRAPING", False),
+            patch(f"{MODULE}.INTER_RESORT_DELAY", 0.0),
+            patch(f"{MODULE}.RESORTS_TABLE", TABLE_NAME),
+            patch(f"{MODULE}.process_elevation_point") as mock_pep,
+        ):
+            mock_ddb.meta.client.batch_get_item.return_value = {
+                "Responses": {TABLE_NAME: [resort]}
+            }
+            mock_pep.return_value = {"success": True, "error": None, "level": "mid"}
+
+            event = {"resort_ids": ["big-white"], "region": "na_west"}
+            result = weather_worker_handler(event, _make_lambda_context())
+
+        body = json.loads(result["body"])
+        stats = body["stats"]
+        assert "start_time" in stats
+        assert "end_time" in stats
+        assert "duration_seconds" in stats
+        assert stats["duration_seconds"] >= 0
+
+    def test_inter_resort_delay(self):
+        """time.sleep should be called between resorts when INTER_RESORT_DELAY > 0."""
+        from handlers.weather_worker import weather_worker_handler
+
+        resort1 = _make_resort_data(
+            "resort-1",
+            elevation_points=[_make_elevation_point_dict("mid")],
+        )
+        resort2 = _make_resort_data(
+            "resort-2",
+            elevation_points=[_make_elevation_point_dict("mid")],
+        )
+
+        with (
+            patch(f"{MODULE}.dynamodb") as mock_ddb,
+            patch(f"{MODULE}.OpenMeteoService"),
+            patch(f"{MODULE}.SnowQualityService"),
+            patch(f"{MODULE}.SnowSummaryService"),
+            patch(f"{MODULE}.OnTheSnowScraper"),
+            patch(f"{MODULE}.ENABLE_SCRAPING", False),
+            patch(f"{MODULE}.INTER_RESORT_DELAY", 1.5),
+            patch(f"{MODULE}.RESORTS_TABLE", TABLE_NAME),
+            patch(f"{MODULE}.time.sleep") as mock_sleep,
+            patch(f"{MODULE}.process_elevation_point") as mock_pep,
+        ):
+            mock_ddb.meta.client.batch_get_item.return_value = {
+                "Responses": {TABLE_NAME: [resort1, resort2]}
+            }
+            mock_pep.return_value = {"success": True, "error": None, "level": "mid"}
+
+            event = {"resort_ids": ["resort-1", "resort-2"], "region": "na_west"}
+            result = weather_worker_handler(event, _make_lambda_context())
+
+        # sleep should be called once per resort
+        assert mock_sleep.call_count == 2
+        mock_sleep.assert_called_with(1.5)
+
+    def test_no_delay_when_zero(self):
+        """time.sleep should not be called when INTER_RESORT_DELAY is 0."""
+        from handlers.weather_worker import weather_worker_handler
+
+        resort = _make_resort_data(
+            "big-white",
+            elevation_points=[_make_elevation_point_dict("mid")],
+        )
+
+        with (
+            patch(f"{MODULE}.dynamodb") as mock_ddb,
+            patch(f"{MODULE}.OpenMeteoService"),
+            patch(f"{MODULE}.SnowQualityService"),
+            patch(f"{MODULE}.SnowSummaryService"),
+            patch(f"{MODULE}.OnTheSnowScraper"),
+            patch(f"{MODULE}.ENABLE_SCRAPING", False),
+            patch(f"{MODULE}.INTER_RESORT_DELAY", 0.0),
+            patch(f"{MODULE}.RESORTS_TABLE", TABLE_NAME),
+            patch(f"{MODULE}.time.sleep") as mock_sleep,
+            patch(f"{MODULE}.process_elevation_point") as mock_pep,
+        ):
+            mock_ddb.meta.client.batch_get_item.return_value = {
+                "Responses": {TABLE_NAME: [resort]}
+            }
+            mock_pep.return_value = {"success": True, "error": None, "level": "mid"}
+
+            event = {"resort_ids": ["big-white"], "region": "na_west"}
+            result = weather_worker_handler(event, _make_lambda_context())
+
+        mock_sleep.assert_not_called()
+
+    def test_batch_get_empty_response(self):
+        """When DynamoDB returns empty Responses, handler should still complete."""
+        from handlers.weather_worker import weather_worker_handler
+
+        with (
+            patch(f"{MODULE}.dynamodb") as mock_ddb,
+            patch(f"{MODULE}.OpenMeteoService"),
+            patch(f"{MODULE}.SnowQualityService"),
+            patch(f"{MODULE}.SnowSummaryService"),
+            patch(f"{MODULE}.OnTheSnowScraper"),
+            patch(f"{MODULE}.ENABLE_SCRAPING", False),
+            patch(f"{MODULE}.INTER_RESORT_DELAY", 0.0),
+            patch(f"{MODULE}.RESORTS_TABLE", TABLE_NAME),
+        ):
+            mock_ddb.meta.client.batch_get_item.return_value = {"Responses": {}}
+
+            event = {"resort_ids": ["nonexistent"], "region": "na_west"}
+            result = weather_worker_handler(event, _make_lambda_context())
+
+        assert result["statusCode"] == 200
+        body = json.loads(result["body"])
+        assert body["stats"]["resorts_processed"] == 0
+
+    def test_parallel_elevation_processing_uses_thread_pool(self):
+        """Verify ThreadPoolExecutor is used for elevation point processing.
+
+        Rather than mocking ThreadPoolExecutor (which breaks as_completed),
+        we let the real executor run and verify process_elevation_point is
+        called for each elevation point concurrently.
+        """
+        from handlers.weather_worker import weather_worker_handler
+
+        resort = _make_resort_data(
+            "big-white",
+            elevation_points=[
+                _make_elevation_point_dict("base"),
+                _make_elevation_point_dict("mid"),
+                _make_elevation_point_dict("top"),
+            ],
+        )
+
+        with (
+            patch(f"{MODULE}.dynamodb") as mock_ddb,
+            patch(f"{MODULE}.OpenMeteoService"),
+            patch(f"{MODULE}.SnowQualityService"),
+            patch(f"{MODULE}.SnowSummaryService"),
+            patch(f"{MODULE}.OnTheSnowScraper"),
+            patch(f"{MODULE}.ENABLE_SCRAPING", False),
+            patch(f"{MODULE}.INTER_RESORT_DELAY", 0.0),
+            patch(f"{MODULE}.RESORTS_TABLE", TABLE_NAME),
+            patch(f"{MODULE}.ELEVATION_CONCURRENCY", 3),
+            patch(f"{MODULE}.process_elevation_point") as mock_pep,
+        ):
+            mock_ddb.meta.client.batch_get_item.return_value = {
+                "Responses": {TABLE_NAME: [resort]}
+            }
+            mock_pep.return_value = {"success": True, "error": None, "level": "mid"}
+
+            event = {"resort_ids": ["big-white"], "region": "na_west"}
+            result = weather_worker_handler(event, _make_lambda_context())
+
+        # All 3 elevation points should have been submitted
+        assert mock_pep.call_count == 3
+        body = json.loads(result["body"])
+        assert body["stats"]["conditions_saved"] == 3
+
+    def test_mixed_success_and_failure_elevation_points(self):
+        """Some elevation points succeed and some fail."""
+        from handlers.weather_worker import weather_worker_handler
+
+        resort = _make_resort_data(
+            "big-white",
+            elevation_points=[
+                _make_elevation_point_dict("base"),
+                _make_elevation_point_dict("mid"),
+                _make_elevation_point_dict("top"),
+            ],
+        )
+
+        call_count = 0
+
+        def alternating_result(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 2:
+                return {"success": False, "error": "API error", "level": "mid"}
+            return {"success": True, "error": None, "level": "base"}
+
+        with (
+            patch(f"{MODULE}.dynamodb") as mock_ddb,
+            patch(f"{MODULE}.OpenMeteoService"),
+            patch(f"{MODULE}.SnowQualityService"),
+            patch(f"{MODULE}.SnowSummaryService"),
+            patch(f"{MODULE}.OnTheSnowScraper"),
+            patch(f"{MODULE}.ENABLE_SCRAPING", False),
+            patch(f"{MODULE}.INTER_RESORT_DELAY", 0.0),
+            patch(f"{MODULE}.RESORTS_TABLE", TABLE_NAME),
+            patch(f"{MODULE}.process_elevation_point") as mock_pep,
+        ):
+            mock_ddb.meta.client.batch_get_item.return_value = {
+                "Responses": {TABLE_NAME: [resort]}
+            }
+            mock_pep.side_effect = alternating_result
+
+            event = {"resort_ids": ["big-white"], "region": "na_west"}
+            result = weather_worker_handler(event, _make_lambda_context())
+
+        body = json.loads(result["body"])
+        assert body["stats"]["conditions_saved"] == 2
+        assert body["stats"]["errors"] == 1
+
+    def test_handler_uses_correct_table_names(self):
+        """Handler should use table names from environment variables."""
+        from handlers.weather_worker import weather_worker_handler
+
+        resort = _make_resort_data(
+            "big-white",
+            elevation_points=[_make_elevation_point_dict("mid")],
+        )
+
+        with (
+            patch(f"{MODULE}.dynamodb") as mock_ddb,
+            patch(f"{MODULE}.OpenMeteoService"),
+            patch(f"{MODULE}.SnowQualityService"),
+            patch(f"{MODULE}.SnowSummaryService"),
+            patch(f"{MODULE}.OnTheSnowScraper"),
+            patch(f"{MODULE}.ENABLE_SCRAPING", False),
+            patch(f"{MODULE}.INTER_RESORT_DELAY", 0.0),
+            patch(f"{MODULE}.RESORTS_TABLE", TABLE_NAME),
+            patch(f"{MODULE}.process_elevation_point") as mock_pep,
+        ):
+            mock_ddb.meta.client.batch_get_item.return_value = {
+                "Responses": {TABLE_NAME: [resort]}
+            }
+            mock_pep.return_value = {"success": True, "error": None, "level": "mid"}
+
+            event = {"resort_ids": ["big-white"], "region": "na_west"}
+            result = weather_worker_handler(event, _make_lambda_context())
+
+        # Verify DynamoDB Table was called with correct table names
+        table_calls = [str(c) for c in mock_ddb.Table.call_args_list]
+        assert any("snow-tracker-resorts" in c for c in table_calls)
+        assert any("snow-tracker-weather-conditions" in c for c in table_calls)
+        assert any("snow-tracker-snow-summary" in c for c in table_calls)
+
+    def test_success_message_in_response(self):
+        """Response body should contain a descriptive success message."""
+        from handlers.weather_worker import weather_worker_handler
+
+        resort = _make_resort_data(
+            "big-white",
+            elevation_points=[_make_elevation_point_dict("mid")],
+        )
+
+        with (
+            patch(f"{MODULE}.dynamodb") as mock_ddb,
+            patch(f"{MODULE}.OpenMeteoService"),
+            patch(f"{MODULE}.SnowQualityService"),
+            patch(f"{MODULE}.SnowSummaryService"),
+            patch(f"{MODULE}.OnTheSnowScraper"),
+            patch(f"{MODULE}.ENABLE_SCRAPING", False),
+            patch(f"{MODULE}.INTER_RESORT_DELAY", 0.0),
+            patch(f"{MODULE}.RESORTS_TABLE", TABLE_NAME),
+            patch(f"{MODULE}.process_elevation_point") as mock_pep,
+        ):
+            mock_ddb.meta.client.batch_get_item.return_value = {
+                "Responses": {TABLE_NAME: [resort]}
+            }
+            mock_pep.return_value = {"success": True, "error": None, "level": "mid"}
+
+            event = {"resort_ids": ["big-white"], "region": "na_west"}
+            result = weather_worker_handler(event, _make_lambda_context())
+
+        body = json.loads(result["body"])
+        assert "Processed 1 resorts" in body["message"]


### PR DESCRIPTION
## Summary
- **test_scraper_worker.py**: 98 tests covering country scraping, resort parsing, error handling, pagination, and handler orchestration
- **test_version_consolidator.py**: 63 tests covering S3 aggregation, resort diffing, versioning, notifications, and handler flow
- **test_weather_worker.py**: 52 tests covering elevation point processing, DynamoDB batch operations, scraper integration, parallel execution, and inter-resort delay; includes RESORTS_TABLE patching to prevent test contamination from integration test environment variables

Total backend tests: 891 → 1104 (+213)

## Test plan
- [x] All 1104 backend tests pass locally (`python -m pytest tests/ -v`)
- [x] No test contamination — weather_worker tests pass both in isolation and with the full suite
- [x] Pre-commit hooks pass (ruff, ruff-format)

🤖 Generated with [Claude Code](https://claude.com/claude-code)