### PR TITLE
Auto-bypass auth in screenshot mode, fix screenshot tests

### DIFF
--- a/ios/SnowTracker/SnowTracker/Sources/SnowTrackerApp.swift
+++ b/ios/SnowTracker/SnowTracker/Sources/SnowTrackerApp.swift
@@ -77,8 +77,15 @@ struct SnowTrackerApp: App {
                 }
             }
             .onAppear {
-                // Check if onboarding is needed
-                showOnboarding = !userPreferencesManager.hasCompletedOnboarding
+                // Auto-authenticate in screenshot/demo mode
+                if ProcessInfo.processInfo.arguments.contains("SCREENSHOT_MODE") ||
+                   ProcessInfo.processInfo.arguments.contains("DEMO_DATA") {
+                    authService.continueWithoutSignIn()
+                    showOnboarding = false
+                } else {
+                    // Check if onboarding is needed
+                    showOnboarding = !userPreferencesManager.hasCompletedOnboarding
+                }
 
                 // Show splash for minimum duration while data loads
                 DispatchQueue.main.asyncAfter(deadline: .now() + 2.5) {
@@ -93,8 +100,10 @@ struct SnowTrackerApp: App {
             }
             .onChange(of: authService.isAuthenticated) { _, isAuthenticated in
                 if isAuthenticated {
-                    // Check if onboarding is needed when user signs in
-                    showOnboarding = !userPreferencesManager.hasCompletedOnboarding
+                    // Skip onboarding in screenshot/demo mode
+                    let isTestMode = ProcessInfo.processInfo.arguments.contains("SCREENSHOT_MODE") ||
+                                     ProcessInfo.processInfo.arguments.contains("DEMO_DATA")
+                    showOnboarding = isTestMode ? false : !userPreferencesManager.hasCompletedOnboarding
 
                     // Request notification permissions when user is authenticated
                     Task {


### PR DESCRIPTION
## Summary
- Auto-authenticate as guest and skip onboarding when `SCREENSHOT_MODE` or `DEMO_DATA` launch args present
- Update App Store screenshot tests to match current tab structure (Best Snow instead of Conditions)
- All 8 iPhone screenshot tests pass, 3 iPad tests correctly skipped

## Test plan
- [x] Screenshot tests pass on iPhone 17 Pro Max simulator
- [x] Unit tests pass (106 tests)
- [x] Normal launch flow unaffected (no test args = normal auth/onboarding)

🤖 Generated with [Claude Code](https://claude.com/claude-code)