### PR TITLE
Fix batch quality endpoint elevation data mismatch

### DIFF
--- a/backend/src/handlers/api_handler.py
+++ b/backend/src/handlers/api_handler.py
@@ -1116,9 +1116,11 @@ def _get_snow_quality_for_resort(resort_id: str) -> dict | None:
         overall_quality = SnowQualityService.calculate_overall_quality(conditions)
         snow_score = None
 
-    # Get representative condition for temperature/snowfall fields (prefer top)
+    # Get representative condition for temperature/snowfall fields (prefer mid)
+    # Mid elevation best represents typical skiing conditions and aligns with
+    # the weighted quality rating (50% top + 35% mid + 15% base)
     representative = None
-    for pref in ["top", "mid", "base"]:
+    for pref in ["mid", "top", "base"]:
         for c in conditions:
             if c.elevation_level == pref:
                 representative = c

--- a/backend/src/services/static_json_generator.py
+++ b/backend/src/services/static_json_generator.py
@@ -255,9 +255,11 @@ class StaticJsonGenerator:
         # Generate overall explanation matching weighted quality level
         explanation = generate_overall_explanation(conditions, overall_quality)
 
-        # Get representative condition for temperature/snowfall fields (prefer top)
+        # Get representative condition for temperature/snowfall fields (prefer mid)
+        # Mid elevation best represents typical skiing conditions and aligns with
+        # the weighted quality rating (50% top + 35% mid + 15% base)
         representative = None
-        for pref_level in ["top", "mid", "base"]:
+        for pref_level in ["mid", "top", "base"]:
             for c in conditions:
                 if c.elevation_level == pref_level:
                     representative = c


### PR DESCRIPTION
## Summary
- Fix data inconsistency in `/api/v1/snow-quality/batch` where temperature and snowfall fields came from TOP elevation while quality rating used a weighted average (50% top + 35% mid + 15% base)
- Change representative elevation preference from top-first to mid-first in both the API handler and static JSON generator
- Mid elevation better represents typical skiing conditions and aligns with the quality explanation text

## Problem
The batch endpoint showed e.g. "48cm fresh snow, -2.3C" (from top) alongside a "fair" quality rating (blended), making it appear the model was wrong when it was actually a data presentation issue affecting ~24 resorts.

## Test plan
- [x] All 1104 backend tests pass
- [ ] Verify batch endpoint returns consistent elevation data after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)