### PR TITLE
HOTFIX: Add python-ulid to Lambda deployment package

### DIFF
--- a/backend/requirements-lambda.txt
+++ b/backend/requirements-lambda.txt
@@ -8,4 +8,5 @@ httpx>=0.25.0
 python-jose[cryptography]>=3.3.0
 python-multipart>=0.0.6
 cachetools>=5.3.0
+python-ulid>=2.2.0
 beautifulsoup4>=4.12.0


### PR DESCRIPTION
## CRITICAL FIX - Production API is down

The `ulid` package was in `requirements.txt` but missing from `requirements-lambda.txt`, 
causing all Lambda functions to fail with `Runtime.ImportModuleError: No module named 'ulid'`.

This affects the chat service and condition report service which import `from ulid import ULID`.

## Test plan
- [ ] Deploy to staging, verify API returns 200
- [ ] Deploy to prod

🤖 Generated with [Claude Code](https://claude.com/claude-code)