### PR TITLE
Fix elevation consistency: explanation temp matches temperature_c

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -21,10 +21,8 @@
 ### 🟡 Medium
 | Issue | Description | Status |
 |-------|-------------|--------|
-| Chat requires Bedrock model access form | Bedrock Claude Sonnet 4.6 requires User action | User action needed |
 | Auto-suggest resort in chat | "How's Whistler" → auto-detect nearest famous resort or user favorite | Backlog |
-| Pass affiliation | Epic/Ikon pass info per resort | Research needed |
-| Apple Sign In Email | Shows "Apple ID (000495...)" instead of email | Backlog |
+| App Store Release | Need provisioning profile with Push Notifications | User action needed |
 
 ### 🟢 Future Features
 | Issue | Description |

--- a/backend/tests/test_quality_explanation.py
+++ b/backend/tests/test_quality_explanation.py
@@ -407,9 +407,13 @@ class TestOverallExplanation:
         ]
         result = generate_overall_explanation(conditions, SnowQuality.POOR)
         assert result is not None
-        # Should mention summit conditions AND lower elevation issues
-        assert "summit" in result.lower()
-        assert "lower" in result.lower() or "icy" in result.lower()
+        # Uses representative (mid) with POOR quality override
+        # Should describe poor conditions using mid's freeze-thaw data
+        assert (
+            "thaw" in result.lower()
+            or "hard" in result.lower()
+            or "refrozen" in result.lower()
+        )
 
     def test_mixed_excellent_top_poor_lower(self):
         """Excellent at top but poor lower → synthesized explanation."""
@@ -427,11 +431,12 @@ class TestOverallExplanation:
                 current_temp_celsius=-2.0,
             ),
         ]
-        # Overall good (between excellent and poor)
+        # Overall good (between excellent and poor), representative is top (no mid)
         result = generate_overall_explanation(conditions, SnowQuality.GOOD)
         assert result is not None
-        # Should not just show the "excellent" explanation
-        assert "summit" in result.lower()
+        # Uses representative (top) with GOOD quality override
+        # Should describe good conditions using top's snow data
+        assert "powder" in result.lower() or "snow" in result.lower()
 
     def test_empty_conditions_returns_none(self):
         """Empty conditions list returns None."""


### PR DESCRIPTION
## Summary
- Fixed bug where `generate_overall_explanation` could pick a different elevation's temperature than the `temperature_c` field, causing contradictory API responses (e.g., explanation says "1°C" but `temperature_c` shows 4.7°C)
- Now always uses the representative condition (mid > top > base) for all weather data in explanations
- Replaced 3 silent `except: pass` handlers with warning-level logging

## Test plan
- [x] All 1307 backend tests pass
- [x] All 38 quality explanation tests pass
- [x] Updated 2 tests to match new consistent behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)