### PR TITLE
Add Epic/Ikon pass badges to resort list views

### DIFF
--- a/ios/SnowTracker/SnowTracker/Sources/Views/FavoritesView.swift
+++ b/ios/SnowTracker/SnowTracker/Sources/Views/FavoritesView.swift
@@ -395,8 +395,31 @@ struct FavoriteResortRow: View {
 
             // Resort info
             VStack(alignment: .leading, spacing: 4) {
-                Text(resort.name)
-                    .font(.headline)
+                HStack {
+                    Text(resort.name)
+                        .font(.headline)
+
+                    if resort.epicPass != nil {
+                        Text("Epic")
+                            .font(.caption2)
+                            .fontWeight(.semibold)
+                            .padding(.horizontal, 5)
+                            .padding(.vertical, 2)
+                            .foregroundStyle(.indigo)
+                            .background(Color.indigo.opacity(0.12))
+                            .clipShape(RoundedRectangle(cornerRadius: 4))
+                    }
+                    if resort.ikonPass != nil {
+                        Text("Ikon")
+                            .font(.caption2)
+                            .fontWeight(.semibold)
+                            .padding(.horizontal, 5)
+                            .padding(.vertical, 2)
+                            .foregroundStyle(.orange)
+                            .background(Color.orange.opacity(0.12))
+                            .clipShape(RoundedRectangle(cornerRadius: 4))
+                    }
+                }
 
                 Text(resort.displayLocation)
                     .font(.caption)

--- a/ios/SnowTracker/SnowTracker/Sources/Views/ResortListView.swift
+++ b/ios/SnowTracker/SnowTracker/Sources/Views/ResortListView.swift
@@ -354,6 +354,28 @@ struct ResortRowView: View {
                                 .foregroundStyle(.blue)
                                 .clipShape(RoundedRectangle(cornerRadius: 4))
                         }
+
+                        // Pass affiliation badges
+                        if resort.epicPass != nil {
+                            Text("Epic")
+                                .font(.caption2)
+                                .fontWeight(.semibold)
+                                .padding(.horizontal, 5)
+                                .padding(.vertical, 2)
+                                .foregroundStyle(.indigo)
+                                .background(Color.indigo.opacity(0.12))
+                                .clipShape(RoundedRectangle(cornerRadius: 4))
+                        }
+                        if resort.ikonPass != nil {
+                            Text("Ikon")
+                                .font(.caption2)
+                                .fontWeight(.semibold)
+                                .padding(.horizontal, 5)
+                                .padding(.vertical, 2)
+                                .foregroundStyle(.orange)
+                                .background(Color.orange.opacity(0.12))
+                                .clipShape(RoundedRectangle(cornerRadius: 4))
+                        }
                     }
 
                     Text(resort.displayLocation)


### PR DESCRIPTION
## Summary
- Added compact Epic (indigo) and Ikon (orange) badge chips next to resort names in both ResortListView and FavoritesView
- Gives users pass affiliation information at a glance without entering the detail view
- Consistent styling with the existing PassBadge in ResortDetailView

## Test plan
- [x] iOS build succeeds
- [x] Visual verification of badge positioning

🤖 Generated with [Claude Code](https://claude.com/claude-code)