### PR TITLE
Add condition reports tool to AI chat

### DIFF
--- a/backend/src/handlers/api_handler.py
+++ b/backend/src/handlers/api_handler.py
@@ -418,6 +418,7 @@ def get_chat_service():
             weather_service=get_weather_service(),
             snow_quality_service=get_snow_quality_service(),
             recommendation_service=get_recommendation_service(),
+            condition_report_service=get_condition_report_service(),
         )
     return _chat_service
 


### PR DESCRIPTION
## Summary
- Adds a `get_condition_reports` tool (7th tool) to the AI chat service
- AI can now reference real user-submitted condition reports when answering questions about resort conditions
- Auto-detect pre-fetches condition reports alongside weather data for mentioned resorts
- Condition reports provide on-the-ground skier feedback that complements sensor-based weather data

## Test plan
- [x] 1319 backend tests pass (3 new tests for condition reports tool)
- [x] Tests cover: empty reports, reports with data, and missing service graceful handling

🤖 Generated with [Claude Code](https://claude.com/claude-code)