### PR TITLE
Add snow history and resort comparison tools to AI chat

### DIFF
--- a/backend/src/handlers/api_handler.py
+++ b/backend/src/handlers/api_handler.py
@@ -419,6 +419,7 @@ def get_chat_service():
             snow_quality_service=get_snow_quality_service(),
             recommendation_service=get_recommendation_service(),
             condition_report_service=get_condition_report_service(),
+            daily_history_service=get_daily_history_service(),
         )
     return _chat_service
 


### PR DESCRIPTION
## Summary
- Add **get_snow_history** tool: AI can now answer "how has the season been?" questions using daily history data (total snowfall, snow days, depth trends)
- Add **compare_resorts** tool: AI can compare 2-4 resorts side-by-side in a single call instead of fetching each individually
- Enhance system prompt with numerical quality score interpretation (6=EXCELLENT through 1=HORRIBLE)
- Wire daily_history_service into ChatService initialization
- Add 6 tests for the new tools (59 total chat tests)

## Test plan
- [x] 59 chat service tests pass
- [x] 1302 backend tests pass
- [ ] Test chat with "how has the season been at Whistler?" query
- [ ] Test chat with "compare Whistler and Jackson Hole" query

🤖 Generated with [Claude Code](https://claude.com/claude-code)