### PR TITLE
Add markdown rendering for AI chat responses

### DIFF
--- a/ios/SnowTracker.xcodeproj/project.pbxproj
+++ b/ios/SnowTracker.xcodeproj/project.pbxproj
@@ -52,6 +52,7 @@
 		E9108540FE0495AA300A4664 /* CardStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7629DBF912C6AF6C0C5845FA /* CardStyle.swift */; };
 		A1B2C3D4E5F6A7B8C9D0E1A1 /* AppBackground.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F6A7B8C9D0E1A2 /* AppBackground.swift */; };
 		A1B2C3D4E5F6A7B8C9D0E1A3 /* WeatherOverlayView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F6A7B8C9D0E1A4 /* WeatherOverlayView.swift */; };
+		AED1CA61C2084A5791090AF3 /* MarkdownTextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA50524DB21E4376AC64BAA2 /* MarkdownTextView.swift */; };
 		C440EFF2F7868A9A09A525C2 /* Configuration.swift in Sources */ = {isa = PBXBuildFile; fileRef = A882E15FD24B57516DE0B29E /* Configuration.swift */; };
 		C9503A1D14E11C37EBD585F7 /* GoogleSignInSwift in Frameworks */ = {isa = PBXBuildFile; productRef = BFEBBB03F51632FE030398C0 /* GoogleSignInSwift */; };
 		CA425D6DF761A30E14DAF304 /* GoogleService-Info.plist.template in Resources */ = {isa = PBXBuildFile; fileRef = C9D8809765B1DAE070C75605 /* GoogleService-Info.plist.template */; };
@@ -131,6 +132,7 @@
 		7629DBF912C6AF6C0C5845FA /* CardStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardStyle.swift; sourceTree = "<group>"; };
 		A1B2C3D4E5F6A7B8C9D0E1A2 /* AppBackground.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppBackground.swift; sourceTree = "<group>"; };
 		A1B2C3D4E5F6A7B8C9D0E1A4 /* WeatherOverlayView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeatherOverlayView.swift; sourceTree = "<group>"; };
+		BA50524DB21E4376AC64BAA2 /* MarkdownTextView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownTextView.swift; sourceTree = "<group>"; };
 		1E48E349AAA6C4BEDDCD317E /* FavoritesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FavoritesView.swift; sourceTree = "<group>"; };
 		22ECDCF89993D8220437C43C /* ResortDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResortDetailView.swift; sourceTree = "<group>"; };
 		279D40CEA622F25142C8FD65 /* NotificationSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationSettingsView.swift; sourceTree = "<group>"; };
@@ -291,6 +293,7 @@
 				B2C3D4E5F6A7B8C9D0E1F2A3 /* TimelineView.swift */,
 				34B3DE91A8041E068949717A /* TripPlanningViews.swift */,
 				A1B2C3D4E5F6A7B8C9D0E1A4 /* WeatherOverlayView.swift */,
+				BA50524DB21E4376AC64BAA2 /* MarkdownTextView.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -580,6 +583,7 @@
 				E9108540FE0495AA300A4664 /* CardStyle.swift in Sources */,
 				A1B2C3D4E5F6A7B8C9D0E1A1 /* AppBackground.swift in Sources */,
 				A1B2C3D4E5F6A7B8C9D0E1A3 /* WeatherOverlayView.swift in Sources */,
+				AED1CA61C2084A5791090AF3 /* MarkdownTextView.swift in Sources */,
 				2699A5371F1EFF464AB8F9E9 /* FeedbackView.swift in Sources */,
 				9BF10F65F1BF8419E4A87267 /* LocationManager.swift in Sources */,
 				8720BD7F787971D36BBEE343 /* Managers.swift in Sources */,

--- a/ios/SnowTracker/SnowTracker/Sources/Views/ChatView.swift
+++ b/ios/SnowTracker/SnowTracker/Sources/Views/ChatView.swift
@@ -238,9 +238,16 @@ private struct MessageBubbleView: View {
             }
 
             VStack(alignment: message.isFromUser ? .trailing : .leading, spacing: 4) {
-                Text(displayedText)
-                    .font(.body)
-                    .foregroundStyle(message.isFromUser ? .white : .primary)
+                Group {
+                    if message.isFromUser {
+                        Text(displayedText)
+                            .font(.body)
+                            .foregroundStyle(.white)
+                    } else {
+                        MarkdownTextView(displayedText, foregroundColor: .primary)
+                            .font(.body)
+                    }
+                }
                     .textSelection(.enabled)
                     .padding(.horizontal, 14)
                     .padding(.vertical, 10)

--- a/ios/SnowTracker/SnowTracker/Sources/Views/MarkdownTextView.swift
+++ b/ios/SnowTracker/SnowTracker/Sources/Views/MarkdownTextView.swift
@@ -1,0 +1,257 @@
+import SwiftUI
+
+/// Renders markdown content with proper formatting for AI chat responses.
+/// Supports headers, bold/italic, bullet/numbered lists, code blocks, and inline code.
+struct MarkdownTextView: View {
+    let text: String
+    let foregroundColor: Color
+
+    init(_ text: String, foregroundColor: Color = .primary) {
+        self.text = text
+        self.foregroundColor = foregroundColor
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            ForEach(Array(parseBlocks().enumerated()), id: \.offset) { _, block in
+                blockView(block)
+            }
+        }
+    }
+
+    // MARK: - Block Types
+
+    private enum MarkdownBlock {
+        case paragraph(String)
+        case header(level: Int, text: String)
+        case codeBlock(language: String?, code: String)
+        case bulletList([String])
+        case numberedList([String])
+    }
+
+    // MARK: - Block Rendering
+
+    @ViewBuilder
+    private func blockView(_ block: MarkdownBlock) -> some View {
+        switch block {
+        case .paragraph(let text):
+            inlineMarkdown(text)
+
+        case .header(let level, let text):
+            Text(inlineAttributed(text))
+                .font(headerFont(level))
+                .fontWeight(.semibold)
+                .foregroundStyle(foregroundColor)
+
+        case .codeBlock(_, let code):
+            Text(code)
+                .font(.system(.caption, design: .monospaced))
+                .padding(10)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .background(Color(.tertiarySystemBackground))
+                .clipShape(RoundedRectangle(cornerRadius: 8))
+
+        case .bulletList(let items):
+            VStack(alignment: .leading, spacing: 4) {
+                ForEach(Array(items.enumerated()), id: \.offset) { _, item in
+                    HStack(alignment: .firstTextBaseline, spacing: 6) {
+                        Text("\u{2022}")
+                            .foregroundStyle(foregroundColor.opacity(0.6))
+                        inlineMarkdown(item)
+                    }
+                }
+            }
+            .padding(.leading, 4)
+
+        case .numberedList(let items):
+            VStack(alignment: .leading, spacing: 4) {
+                ForEach(Array(items.enumerated()), id: \.offset) { index, item in
+                    HStack(alignment: .firstTextBaseline, spacing: 6) {
+                        Text("\(index + 1).")
+                            .foregroundStyle(foregroundColor.opacity(0.6))
+                            .monospacedDigit()
+                        inlineMarkdown(item)
+                    }
+                }
+            }
+            .padding(.leading, 4)
+        }
+    }
+
+    private func headerFont(_ level: Int) -> Font {
+        switch level {
+        case 1: return .title3
+        case 2: return .headline
+        default: return .subheadline
+        }
+    }
+
+    // MARK: - Inline Markdown Rendering
+
+    private func inlineMarkdown(_ text: String) -> some View {
+        Text(inlineAttributed(text))
+            .foregroundStyle(foregroundColor)
+    }
+
+    /// Convert inline markdown (bold, italic, code, links) to AttributedString
+    private func inlineAttributed(_ text: String) -> AttributedString {
+        // Try SwiftUI's built-in markdown parsing
+        if let attributed = try? AttributedString(markdown: text, options: .init(interpretedSyntax: .inlineOnlyPreservingWhitespace)) {
+            return attributed
+        }
+        return AttributedString(text)
+    }
+
+    // MARK: - Block Parser
+
+    private func parseBlocks() -> [MarkdownBlock] {
+        let lines = text.components(separatedBy: "\n")
+        var blocks: [MarkdownBlock] = []
+        var index = 0
+
+        while index < lines.count {
+            let line = lines[index]
+            let trimmed = line.trimmingCharacters(in: .whitespaces)
+
+            // Skip empty lines
+            if trimmed.isEmpty {
+                index += 1
+                continue
+            }
+
+            // Code block
+            if trimmed.hasPrefix("```") {
+                let language = String(trimmed.dropFirst(3)).trimmingCharacters(in: .whitespaces)
+                var codeLines: [String] = []
+                index += 1
+                while index < lines.count {
+                    if lines[index].trimmingCharacters(in: .whitespaces).hasPrefix("```") {
+                        index += 1
+                        break
+                    }
+                    codeLines.append(lines[index])
+                    index += 1
+                }
+                blocks.append(.codeBlock(
+                    language: language.isEmpty ? nil : language,
+                    code: codeLines.joined(separator: "\n")
+                ))
+                continue
+            }
+
+            // Header
+            if let (level, headerText) = parseHeader(trimmed) {
+                blocks.append(.header(level: level, text: headerText))
+                index += 1
+                continue
+            }
+
+            // Bullet list
+            if trimmed.hasPrefix("- ") || trimmed.hasPrefix("* ") || trimmed.hasPrefix("+ ") {
+                var items: [String] = []
+                while index < lines.count {
+                    let listLine = lines[index].trimmingCharacters(in: .whitespaces)
+                    if listLine.hasPrefix("- ") {
+                        items.append(String(listLine.dropFirst(2)))
+                    } else if listLine.hasPrefix("* ") {
+                        items.append(String(listLine.dropFirst(2)))
+                    } else if listLine.hasPrefix("+ ") {
+                        items.append(String(listLine.dropFirst(2)))
+                    } else if listLine.isEmpty {
+                        index += 1
+                        break
+                    } else {
+                        break
+                    }
+                    index += 1
+                }
+                blocks.append(.bulletList(items))
+                continue
+            }
+
+            // Numbered list
+            if isNumberedListItem(trimmed) {
+                var items: [String] = []
+                while index < lines.count {
+                    let listLine = lines[index].trimmingCharacters(in: .whitespaces)
+                    if let itemText = parseNumberedListItem(listLine) {
+                        items.append(itemText)
+                    } else if listLine.isEmpty {
+                        index += 1
+                        break
+                    } else {
+                        break
+                    }
+                    index += 1
+                }
+                blocks.append(.numberedList(items))
+                continue
+            }
+
+            // Regular paragraph - collect consecutive non-empty, non-special lines
+            var paragraphLines: [String] = []
+            while index < lines.count {
+                let paraLine = lines[index]
+                let paraTrimmed = paraLine.trimmingCharacters(in: .whitespaces)
+                if paraTrimmed.isEmpty
+                    || paraTrimmed.hasPrefix("```")
+                    || paraTrimmed.hasPrefix("# ")
+                    || paraTrimmed.hasPrefix("## ")
+                    || paraTrimmed.hasPrefix("### ")
+                    || paraTrimmed.hasPrefix("- ")
+                    || paraTrimmed.hasPrefix("* ")
+                    || paraTrimmed.hasPrefix("+ ")
+                    || isNumberedListItem(paraTrimmed) {
+                    break
+                }
+                paragraphLines.append(paraTrimmed)
+                index += 1
+            }
+            if !paragraphLines.isEmpty {
+                blocks.append(.paragraph(paragraphLines.joined(separator: " ")))
+            }
+        }
+
+        return blocks
+    }
+
+    // MARK: - Parsing Helpers
+
+    /// Parse a header line like "## Title" → (level: 2, text: "Title")
+    private func parseHeader(_ line: String) -> (Int, String)? {
+        var level = 0
+        var remaining = line[...]
+        while remaining.hasPrefix("#") && level < 3 {
+            remaining = remaining.dropFirst()
+            level += 1
+        }
+        guard level > 0, remaining.hasPrefix(" ") else { return nil }
+        let text = remaining.drop(while: { $0 == " " })
+        guard !text.isEmpty else { return nil }
+        return (level, String(text))
+    }
+
+    /// Check if a line starts with a numbered list pattern like "1. "
+    private func isNumberedListItem(_ line: String) -> Bool {
+        parseNumberedListItem(line) != nil
+    }
+
+    /// Parse a numbered list item like "1. Text" → "Text"
+    private func parseNumberedListItem(_ line: String) -> String? {
+        let chars = Array(line)
+        var i = 0
+        // Skip digits
+        while i < chars.count && chars[i].isNumber {
+            i += 1
+        }
+        guard i > 0, i < chars.count, chars[i] == "." else { return nil }
+        i += 1
+        guard i < chars.count, chars[i] == " " else { return nil }
+        i += 1
+        // Skip leading spaces
+        while i < chars.count && chars[i] == " " {
+            i += 1
+        }
+        return String(chars[i...])
+    }
+}


### PR DESCRIPTION
## Summary
- Add `MarkdownTextView` that renders markdown content with proper formatting
- AI chat responses now display headers, bold/italic, bullet lists, numbered lists, code blocks, and inline code
- User messages remain as plain text bubbles

## Test plan
- [x] iOS build succeeds
- [x] 106 iOS tests pass
- [ ] Visual verification: send AI questions that trigger markdown responses (lists, bold, code)
- [ ] Verify streaming text still works correctly with markdown rendering
- [ ] Verify dark mode rendering

🤖 Generated with [Claude Code](https://claude.com/claude-code)