### PR TITLE
Add forecast badge to favorites

### DIFF
--- a/ios/SnowTracker/SnowTracker/Sources/Views/FavoritesView.swift
+++ b/ios/SnowTracker/SnowTracker/Sources/Views/FavoritesView.swift
@@ -451,6 +451,13 @@ struct FavoriteResortRow: View {
 
             Spacer()
 
+            // Forecast badge when significant snow is expected
+            if let condition = topCondition,
+               let predicted48h = condition.predictedSnow48hCm,
+               predicted48h >= 5 {
+                ForecastBadge(hours: 48, cm: predicted48h, prefs: userPreferencesManager.preferredUnits)
+            }
+
             // Arrow indicator
             Image(systemName: "chevron.right")
                 .foregroundStyle(.secondary)


### PR DESCRIPTION
## Summary
- Show forecast badge on favorite resort rows when 5+ cm snow is predicted in next 48h
- Reuses existing `ForecastBadge` component from the map view
- Helps users quickly spot which favorites have significant snow incoming

## Test plan
- [x] iOS build succeeds
- [ ] Visual verification with favorites that have forecast data

🤖 Generated with [Claude Code](https://claude.com/claude-code)