### PR TITLE
Add snow depth and forecast data to batch quality endpoint

### DIFF
--- a/backend/src/services/static_json_generator.py
+++ b/backend/src/services/static_json_generator.py
@@ -235,6 +235,8 @@ class StaticJsonGenerator:
                 "temperature_c": None,
                 "snowfall_fresh_cm": None,
                 "snowfall_24h_cm": None,
+                "snow_depth_cm": None,
+                "predicted_snow_48h_cm": None,
             }
 
         # Calculate overall quality from weighted raw scores (top 50%, mid 35%, base 15%)
@@ -297,6 +299,10 @@ class StaticJsonGenerator:
             ),
             "snowfall_24h_cm": (
                 representative.snowfall_24h_cm if representative else None
+            ),
+            "snow_depth_cm": (representative.snow_depth_cm if representative else None),
+            "predicted_snow_48h_cm": (
+                representative.predicted_snow_48h_cm if representative else None
             ),
         }
 

--- a/ios/SnowTracker/SnowTracker/Sources/Services/APIClient.swift
+++ b/ios/SnowTracker/SnowTracker/Sources/Services/APIClient.swift
@@ -1230,6 +1230,8 @@ struct SnowQualitySummaryLight: Codable {
     let temperatureC: Double?
     let snowfallFreshCm: Double?
     let snowfall24hCm: Double?
+    let snowDepthCm: Double?
+    let predictedSnow48hCm: Double?
 
     private enum CodingKeys: String, CodingKey {
         case resortId = "resort_id"
@@ -1240,12 +1242,15 @@ struct SnowQualitySummaryLight: Codable {
         case temperatureC = "temperature_c"
         case snowfallFreshCm = "snowfall_fresh_cm"
         case snowfall24hCm = "snowfall_24h_cm"
+        case snowDepthCm = "snow_depth_cm"
+        case predictedSnow48hCm = "predicted_snow_48h_cm"
     }
 
     // Explicit initializer for cache reconstruction
     init(resortId: String, overallQuality: String, snowScore: Int? = nil,
          explanation: String? = nil, lastUpdated: String?,
-         temperatureC: Double? = nil, snowfallFreshCm: Double? = nil, snowfall24hCm: Double? = nil) {
+         temperatureC: Double? = nil, snowfallFreshCm: Double? = nil, snowfall24hCm: Double? = nil,
+         snowDepthCm: Double? = nil, predictedSnow48hCm: Double? = nil) {
         self.resortId = resortId
         self.overallQuality = overallQuality
         self.snowScore = snowScore
@@ -1254,6 +1259,8 @@ struct SnowQualitySummaryLight: Codable {
         self.temperatureC = temperatureC
         self.snowfallFreshCm = snowfallFreshCm
         self.snowfall24hCm = snowfall24hCm
+        self.snowDepthCm = snowDepthCm
+        self.predictedSnow48hCm = predictedSnow48hCm
     }
 
     /// Snow quality with frontend temperature override

--- a/ios/SnowTracker/SnowTracker/Sources/Views/ResortListView.swift
+++ b/ios/SnowTracker/SnowTracker/Sources/Views/ResortListView.swift
@@ -537,9 +537,14 @@ struct ResortRowView: View {
 
                     Spacer()
 
-                    Label(condition.formattedTimestamp, systemImage: "clock")
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
+                    // Forecast badge or timestamp
+                    if let predicted = condition.predictedSnow48hCm, predicted >= 5 {
+                        ForecastBadge(hours: 48, cm: predicted, prefs: userPreferencesManager.preferredUnits)
+                    } else {
+                        Label(condition.formattedTimestamp, systemImage: "clock")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
                 }
             } else if let summary = snowQualitySummary,
                       summary.temperatureC != nil || summary.snowfallFreshCm != nil {
@@ -560,7 +565,9 @@ struct ResortRowView: View {
 
                     Spacer()
 
-                    if let timestamp = summary.formattedTimestamp {
+                    if let predicted = summary.predictedSnow48hCm, predicted >= 5 {
+                        ForecastBadge(hours: 48, cm: predicted, prefs: userPreferencesManager.preferredUnits)
+                    } else if let timestamp = summary.formattedTimestamp {
                         Label(timestamp, systemImage: "clock")
                             .font(.caption)
                             .foregroundStyle(.secondary)


### PR DESCRIPTION
## Summary
- Add `snow_depth_cm` and `predicted_snow_48h_cm` to static JSON snow quality summaries
- Add corresponding fields to iOS `SnowQualitySummaryLight` model
- Show forecast badges in resort list view when significant snow is predicted (≥5cm in 48h)

## Test plan
- [x] Backend tests pass (1330 tests)
- [x] iOS tests pass (106 tests)
- [ ] Verify forecast badges appear in resort list after static JSON regeneration

🤖 Generated with [Claude Code](https://claude.com/claude-code)