### PR TITLE
Add storms incoming section to favorites summary card

### DIFF
--- a/ios/SnowTracker/SnowTracker/Sources/Views/FavoritesView.swift
+++ b/ios/SnowTracker/SnowTracker/Sources/Views/FavoritesView.swift
@@ -505,6 +505,15 @@ struct FavoritesSummaryCard: View {
             .reduce(0, +)
     }
 
+    private var stormsIncoming: [(resort: Resort, cm: Double)] {
+        resorts.compactMap { resort -> (Resort, Double)? in
+            guard let predicted = snowConditionsManager.snowQualitySummaries[resort.id]?.predictedSnow48hCm,
+                  predicted >= 10 else { return nil }
+            return (resort, predicted)
+        }
+        .sorted { $0.1 > $1.1 }
+    }
+
     var body: some View {
         VStack(spacing: 12) {
             // Header row
@@ -581,6 +590,29 @@ struct FavoritesSummaryCard: View {
                             }
                         }
                         Spacer()
+                    }
+                }
+            }
+
+            // Storms incoming
+            if !stormsIncoming.isEmpty {
+                Divider()
+
+                VStack(alignment: .leading, spacing: 6) {
+                    Label(
+                        stormsIncoming.count == 1 ? "Storm incoming" : "\(stormsIncoming.count) storms incoming",
+                        systemImage: "cloud.snow.fill"
+                    )
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(.cyan)
+
+                    ForEach(stormsIncoming.prefix(3), id: \.resort.id) { item in
+                        HStack(spacing: 6) {
+                            Text(item.resort.name)
+                                .font(.caption)
+                            Spacer()
+                            ForecastBadge(hours: 48, cm: item.cm, prefs: userPreferencesManager.preferredUnits)
+                        }
                     }
                 }
             }


### PR DESCRIPTION
## Summary
- Add "storms incoming" section to the FavoritesSummaryCard when any favorited resorts have ≥10cm predicted snowfall in the next 48 hours
- Shows up to 3 resorts with the most predicted snow, each with a ForecastBadge
- Helps users quickly spot powder days at their favorite resorts without scrolling

## Test plan
- [x] iOS build succeeds
- [x] Visual verification: storms section appears when favorites have predicted snow ≥10cm
- [x] Hidden when no storms predicted

🤖 Generated with [Claude Code](https://claude.com/claude-code)