### PR TITLE
Improve resort search to match country codes and pass types

### DIFF
--- a/ios/SnowTracker/SnowTracker/Sources/Views/ResortListView.swift
+++ b/ios/SnowTracker/SnowTracker/Sources/Views/ResortListView.swift
@@ -98,7 +98,10 @@ struct ResortListView: View {
             searchFiltered = passFiltered.filter { resort in
                 resort.name.localizedCaseInsensitiveContains(searchText) ||
                 resort.countryName.localizedCaseInsensitiveContains(searchText) ||
-                resort.region.localizedCaseInsensitiveContains(searchText)
+                resort.country.localizedCaseInsensitiveContains(searchText) ||
+                resort.region.localizedCaseInsensitiveContains(searchText) ||
+                (resort.epicPass != nil && "epic".localizedCaseInsensitiveContains(searchText)) ||
+                (resort.ikonPass != nil && "ikon".localizedCaseInsensitiveContains(searchText))
             }
         }
 


### PR DESCRIPTION
## Summary
- Search now matches 2-letter country codes (e.g., typing "CA" finds Canadian resorts)
- Search matches pass affiliations (typing "epic" or "ikon" shows matching resorts)

## Test plan
- [x] iOS build succeeds
- [x] Search "CA" shows Canadian resorts
- [x] Search "epic" shows Epic pass resorts

🤖 Generated with [Claude Code](https://claude.com/claude-code)