### PR TITLE
Add storm badge to Favorites tab

### DIFF
--- a/ios/SnowTracker/SnowTracker/Sources/SnowTrackerApp.swift
+++ b/ios/SnowTracker/SnowTracker/Sources/SnowTrackerApp.swift
@@ -132,6 +132,17 @@ struct MainTabView: View {
     @State private var selectedTab = 0
     @State private var deepLinkResort: Resort?
     @State private var showingChat = false
+    @ObservedObject private var userPrefs = UserPreferencesManager.shared
+
+    /// Number of favorited resorts with significant predicted snow (≥10cm in 48h)
+    private var favoritesStormCount: Int {
+        userPrefs.favoriteResorts.filter { resortId in
+            guard let predicted = snowConditionsManager.snowQualitySummaries[resortId]?.predictedSnow48hCm else {
+                return false
+            }
+            return predicted >= 10
+        }.count
+    }
 
     var body: some View {
         ZStack(alignment: .bottomTrailing) {
@@ -169,6 +180,7 @@ struct MainTabView: View {
                             Text("Favorites")
                         }
                         .tag(3)
+                        .badge(favoritesStormCount)
 
                     SettingsView()
                         .environmentObject(authService)


### PR DESCRIPTION
## Summary
- Add a badge count to the Favorites tab showing how many favorited resorts have ≥10cm of snow predicted in the next 48 hours
- Uses the `predictedSnow48hCm` field from the batch snow quality summary
- Drives engagement by alerting users to powder days at a glance

## Test plan
- [x] iOS build succeeds
- [x] Badge shows when favorites have predicted snow ≥10cm
- [x] Badge hidden when no storms predicted

🤖 Generated with [Claude Code](https://claude.com/claude-code)