### PR TITLE
Extract PassBadge to shared component

### DIFF
--- a/ios/SnowTracker/SnowTracker/Sources/Views/CardStyle.swift
+++ b/ios/SnowTracker/SnowTracker/Sources/Views/CardStyle.swift
@@ -38,3 +38,36 @@ extension View {
             .shadow(color: .black.opacity(0.08), radius: 2, x: 0, y: 1)
     }
 }
+
+// MARK: - Pass Badge
+
+struct PassBadge: View {
+    let passName: String
+    let detail: String
+    let color: Color
+
+    init(passName: String, detail: String = "", color: Color) {
+        self.passName = passName
+        self.detail = detail
+        self.color = color
+    }
+
+    var body: some View {
+        HStack(spacing: 3) {
+            Text(passName)
+                .font(.caption2)
+                .fontWeight(.bold)
+            if !detail.isEmpty && detail != "Unlimited" {
+                Text(detail)
+                    .font(.caption2)
+            }
+        }
+        .padding(.horizontal, 6)
+        .padding(.vertical, 2)
+        .foregroundStyle(color)
+        .background(color.opacity(0.12))
+        .clipShape(RoundedRectangle(cornerRadius: 4))
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("\(passName) Pass\(detail.isEmpty || detail == "Unlimited" ? "" : ": \(detail)")")
+    }
+}

--- a/ios/SnowTracker/SnowTracker/Sources/Views/FavoritesView.swift
+++ b/ios/SnowTracker/SnowTracker/Sources/Views/FavoritesView.swift
@@ -417,24 +417,10 @@ struct FavoriteResortRow: View {
                         .font(.headline)
 
                     if resort.epicPass != nil {
-                        Text("Epic")
-                            .font(.caption2)
-                            .fontWeight(.semibold)
-                            .padding(.horizontal, 5)
-                            .padding(.vertical, 2)
-                            .foregroundStyle(.indigo)
-                            .background(Color.indigo.opacity(0.12))
-                            .clipShape(RoundedRectangle(cornerRadius: 4))
+                        PassBadge(passName: "Epic", color: .indigo)
                     }
                     if resort.ikonPass != nil {
-                        Text("Ikon")
-                            .font(.caption2)
-                            .fontWeight(.semibold)
-                            .padding(.horizontal, 5)
-                            .padding(.vertical, 2)
-                            .foregroundStyle(.orange)
-                            .background(Color.orange.opacity(0.12))
-                            .clipShape(RoundedRectangle(cornerRadius: 4))
+                        PassBadge(passName: "Ikon", color: .orange)
                     }
                 }
 

--- a/ios/SnowTracker/SnowTracker/Sources/Views/ResortDetailView.swift
+++ b/ios/SnowTracker/SnowTracker/Sources/Views/ResortDetailView.swift
@@ -802,33 +802,6 @@ struct ResortDetailView: View {
     }
 }
 
-// MARK: - Pass Badge
-
-private struct PassBadge: View {
-    let passName: String
-    let detail: String
-    let color: Color
-
-    var body: some View {
-        HStack(spacing: 3) {
-            Text(passName)
-                .font(.caption2)
-                .fontWeight(.bold)
-            if detail != "Unlimited" {
-                Text(detail)
-                    .font(.caption2)
-            }
-        }
-        .padding(.horizontal, 6)
-        .padding(.vertical, 2)
-        .foregroundStyle(color)
-        .background(color.opacity(0.12))
-        .clipShape(RoundedRectangle(cornerRadius: 4))
-        .accessibilityElement(children: .combine)
-        .accessibilityLabel("\(passName) Pass: \(detail)")
-    }
-}
-
 // MARK: - Share Sheet
 
 struct ShareSheet: UIViewControllerRepresentable {

--- a/ios/SnowTracker/SnowTracker/Sources/Views/ResortListView.swift
+++ b/ios/SnowTracker/SnowTracker/Sources/Views/ResortListView.swift
@@ -469,24 +469,10 @@ struct ResortRowView: View {
 
                         // Pass affiliation badges
                         if resort.epicPass != nil {
-                            Text("Epic")
-                                .font(.caption2)
-                                .fontWeight(.semibold)
-                                .padding(.horizontal, 5)
-                                .padding(.vertical, 2)
-                                .foregroundStyle(.indigo)
-                                .background(Color.indigo.opacity(0.12))
-                                .clipShape(RoundedRectangle(cornerRadius: 4))
+                            PassBadge(passName: "Epic", color: .indigo)
                         }
                         if resort.ikonPass != nil {
-                            Text("Ikon")
-                                .font(.caption2)
-                                .fontWeight(.semibold)
-                                .padding(.horizontal, 5)
-                                .padding(.vertical, 2)
-                                .foregroundStyle(.orange)
-                                .background(Color.orange.opacity(0.12))
-                                .clipShape(RoundedRectangle(cornerRadius: 4))
+                            PassBadge(passName: "Ikon", color: .orange)
                         }
                     }
 


### PR DESCRIPTION
## Summary
- Moves PassBadge from private struct in ResortDetailView to shared component in CardStyle.swift
- Replaces inline pass badge code in ResortListView and FavoritesView (~30 LoC reduction)
- Adds accessibility labels to the shared component

## Test plan
- [x] iOS build succeeds
- [ ] Pass badges render correctly in resort list, favorites, and detail views

🤖 Generated with [Claude Code](https://claude.com/claude-code)