### PR TITLE
Enhance share card and add pass badges to recommendations

### DIFF
--- a/ios/SnowTracker/SnowTracker/Sources/Views/ConditionsCardRenderer.swift
+++ b/ios/SnowTracker/SnowTracker/Sources/Views/ConditionsCardRenderer.swift
@@ -119,20 +119,36 @@ private struct ConditionsCardView: View {
                 Divider()
 
                 HStack(spacing: 0) {
-                    statCell(
-                        icon: "cloud.snow",
-                        label: "24h Snowfall",
-                        value: condition.formattedSnowfall24hWithPrefs(prefs)
-                    )
+                    if let depth = condition.snowDepthCm, depth > 0 {
+                        statCell(
+                            icon: "mountain.2.fill",
+                            label: "Snow Depth",
+                            value: WeatherCondition.formatSnow(depth, prefs: prefs)
+                        )
+                    } else {
+                        statCell(
+                            icon: "cloud.snow",
+                            label: "24h Snowfall",
+                            value: condition.formattedSnowfall24hWithPrefs(prefs)
+                        )
+                    }
 
                     Divider()
                         .frame(height: 50)
 
-                    statCell(
-                        icon: "wind",
-                        label: "Wind",
-                        value: condition.formattedWindSpeedWithPrefs(prefs)
-                    )
+                    if let predicted = condition.predictedSnow48hCm, predicted >= 5 {
+                        statCell(
+                            icon: "cloud.snow.fill",
+                            label: "48h Forecast",
+                            value: "+\(WeatherCondition.formatSnow(predicted, prefs: prefs))"
+                        )
+                    } else {
+                        statCell(
+                            icon: "wind",
+                            label: "Wind",
+                            value: condition.formattedWindSpeedWithPrefs(prefs)
+                        )
+                    }
                 }
                 .padding(.vertical, 12)
                 .background(Color(.systemBackground))

--- a/ios/SnowTracker/SnowTracker/Sources/Views/RecommendationsView.swift
+++ b/ios/SnowTracker/SnowTracker/Sources/Views/RecommendationsView.swift
@@ -323,9 +323,18 @@ struct RecommendationCard: View {
             // Header with resort name and quality badge
             HStack {
                 VStack(alignment: .leading, spacing: 4) {
-                    Text(recommendation.resort.name)
-                        .font(.headline)
-                        .foregroundStyle(.primary)
+                    HStack(spacing: 6) {
+                        Text(recommendation.resort.name)
+                            .font(.headline)
+                            .foregroundStyle(.primary)
+
+                        if recommendation.resort.epicPass != nil {
+                            PassBadge(passName: "Epic", color: .indigo)
+                        }
+                        if recommendation.resort.ikonPass != nil {
+                            PassBadge(passName: "Ikon", color: .orange)
+                        }
+                    }
 
                     Text(recommendation.resort.displayLocation)
                         .font(.caption)


### PR DESCRIPTION
## Summary
- **Share card image**: Now shows snow depth and 48h forecast when available, replacing the less useful 24h snowfall and wind stats
- **Recommendation cards**: Show Epic/Ikon pass badges next to resort name for quick pass affiliation visibility

## Test plan
- [x] iOS build succeeds
- [ ] Share a resort with snow depth data — verify depth shows in share image
- [ ] Share a resort with 48h forecast — verify forecast shows in share image
- [ ] Check Best Snow tab — verify pass badges on recommendation cards

🤖 Generated with [Claude Code](https://claude.com/claude-code)