### PR TITLE
Fix elevation display to respect unit preferences

### DIFF
--- a/ios/SnowTracker/SnowTracker/Sources/Models/Resort.swift
+++ b/ios/SnowTracker/SnowTracker/Sources/Models/Resort.swift
@@ -75,6 +75,10 @@ struct ElevationPoint: Codable, Identifiable, Hashable {
     var formattedMeters: String {
         (Self.elevationFormatter.string(from: NSNumber(value: elevationMeters)) ?? "\(Int(elevationMeters))") + " m"
     }
+
+    func formattedElevation(prefs: UnitPreferences) -> String {
+        prefs.distance == .metric ? formattedMeters : formattedFeet
+    }
 }
 
 struct Resort: Codable, Identifiable, Hashable {
@@ -139,11 +143,17 @@ struct Resort: Codable, Identifiable, Hashable {
     }
 
     var elevationRange: String {
-        let elevations = elevationPoints.map { Int($0.elevationFeet) }.sorted()
+        elevationRange(prefs: nil)
+    }
+
+    func elevationRange(prefs: UnitPreferences?) -> String {
+        let useMetric = prefs?.distance == .metric
+        let elevations = elevationPoints.map { useMetric ? Int($0.elevationMeters) : Int($0.elevationFeet) }.sorted()
         guard let min = elevations.first, let max = elevations.last else {
             return "Unknown elevation"
         }
-        return "\(min) - \(max) ft"
+        let unit = useMetric ? "m" : "ft"
+        return "\(min) - \(max) \(unit)"
     }
 
     var baseElevation: ElevationPoint? {

--- a/ios/SnowTracker/SnowTracker/Sources/Views/ResortDetailView.swift
+++ b/ios/SnowTracker/SnowTracker/Sources/Views/ResortDetailView.swift
@@ -214,7 +214,7 @@ struct ResortDetailView: View {
                         .font(.subheadline)
                         .foregroundStyle(.secondary)
 
-                    Text(resort.elevationRange)
+                    Text(resort.elevationRange(prefs: userPreferencesManager.preferredUnits))
                         .font(.caption)
                         .foregroundStyle(.secondary)
 
@@ -337,7 +337,7 @@ struct ResortDetailView: View {
             Picker("Elevation", selection: $selectedElevation) {
                 ForEach(ElevationLevel.allCases, id: \.self) { level in
                     if let point = resort.elevationPoint(for: level) {
-                        Text("\(level.displayName) - \(point.formattedFeet)")
+                        Text("\(level.displayName) - \(point.formattedElevation(prefs: userPreferencesManager.preferredUnits))")
                             .tag(level)
                     }
                 }
@@ -704,7 +704,7 @@ struct ResortDetailView: View {
                             Text(level.displayName)
                                 .font(.body)
                                 .fontWeight(.medium)
-                            Text(point.formattedFeet)
+                            Text(point.formattedElevation(prefs: userPreferencesManager.preferredUnits))
                                 .font(.caption)
                                 .foregroundStyle(.secondary)
                         }

--- a/ios/SnowTracker/SnowTracker/Sources/Views/ResortListView.swift
+++ b/ios/SnowTracker/SnowTracker/Sources/Views/ResortListView.swift
@@ -480,7 +480,7 @@ struct ResortRowView: View {
                         .font(.subheadline)
                         .foregroundStyle(.secondary)
 
-                    Text(resort.elevationRange)
+                    Text(resort.elevationRange(prefs: userPreferencesManager.preferredUnits))
                         .font(.caption)
                         .foregroundStyle(.secondary)
                 }

--- a/ios/SnowTracker/SnowTracker/Sources/Views/ResortMapView.swift
+++ b/ios/SnowTracker/SnowTracker/Sources/Views/ResortMapView.swift
@@ -575,7 +575,7 @@ struct ResortMapDetailSheet: View {
                         .font(.subheadline)
                         .foregroundStyle(.secondary)
 
-                    Text(resort.elevationRange)
+                    Text(resort.elevationRange(prefs: userPreferencesManager.preferredUnits))
                         .font(.caption)
                         .foregroundStyle(.secondary)
                 }


### PR DESCRIPTION
## Summary
- Elevation picker, header, list view, and map view now show meters for metric users and feet for imperial users
- Added `formattedElevation(prefs:)` and `elevationRange(prefs:)` methods to `ElevationPoint` and `Resort`
- Previously all elevation displays were hardcoded to feet

## Test plan
- [ ] Toggle unit preference to metric and verify elevations show in meters
- [ ] Verify elevation picker, resort header, list view, and map view all respect the setting
- [ ] Build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)