### PR TITLE
Add snow depth, forecast and pass badges to comparison

### DIFF
--- a/ios/SnowTracker/SnowTracker/Sources/ViewModels/ComparisonViewModel.swift
+++ b/ios/SnowTracker/SnowTracker/Sources/ViewModels/ComparisonViewModel.swift
@@ -116,10 +116,24 @@ final class ComparisonViewModel: ObservableObject {
             }
             guard let best = values.min(by: { $0.1 < $1.1 }) else { return [] }
             return Set(values.filter { $0.1 == best.1 }.map { $0.0 })
+
+        case .snowDepth:
+            let values = selectedResorts.compactMap { r in
+                topCondition(for: r.id)?.snowDepthCm.map { (r.id, $0) }
+            }
+            guard let best = values.max(by: { $0.1 < $1.1 }), best.1 > 0 else { return [] }
+            return Set(values.filter { $0.1 == best.1 }.map { $0.0 })
+
+        case .forecast:
+            let values = selectedResorts.compactMap { r in
+                topCondition(for: r.id)?.predictedSnow48hCm.map { (r.id, $0) }
+            }
+            guard let best = values.max(by: { $0.1 < $1.1 }), best.1 > 0 else { return [] }
+            return Set(values.filter { $0.1 == best.1 }.map { $0.0 })
         }
     }
 }
 
 enum ComparisonMetric {
-    case quality, snowScore, freshSnow, temperature, wind
+    case quality, snowScore, freshSnow, temperature, wind, snowDepth, forecast
 }

--- a/ios/SnowTracker/SnowTracker/Sources/Views/ResortComparisonView.swift
+++ b/ios/SnowTracker/SnowTracker/Sources/Views/ResortComparisonView.swift
@@ -173,6 +173,39 @@ struct ResortComparisonView: View {
                     }
                 }
 
+                // Snow depth
+                comparisonSection("Snow Depth", metric: .snowDepth) { resortId in
+                    if let condition = viewModel.topCondition(for: resortId),
+                       let depth = condition.snowDepthCm, depth > 0 {
+                        VStack(spacing: 4) {
+                            Text(WeatherCondition.formatSnow(depth, prefs: userPreferencesManager.preferredUnits))
+                                .font(.subheadline)
+                                .fontWeight(.medium)
+                        }
+                    } else {
+                        Text("--")
+                            .font(.subheadline)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+
+                // 48h forecast
+                comparisonSection("48h Forecast", metric: .forecast) { resortId in
+                    if let condition = viewModel.topCondition(for: resortId),
+                       let predicted = condition.predictedSnow48hCm, predicted > 0 {
+                        VStack(spacing: 4) {
+                            Text("+\(WeatherCondition.formatSnow(predicted, prefs: userPreferencesManager.preferredUnits))")
+                                .font(.subheadline)
+                                .fontWeight(.medium)
+                                .foregroundStyle(.blue)
+                        }
+                    } else {
+                        Text("--")
+                            .font(.subheadline)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+
                 // 24h snowfall
                 comparisonSection("24h Snowfall", metric: .freshSnow) { resortId in
                     if let condition = viewModel.topCondition(for: resortId) {
@@ -224,6 +257,17 @@ struct ResortComparisonView: View {
                     Text(resort.country)
                         .font(.caption2)
                         .foregroundStyle(.secondary)
+
+                    if resort.epicPass != nil || resort.ikonPass != nil {
+                        HStack(spacing: 4) {
+                            if resort.epicPass != nil {
+                                PassBadge(passName: "Epic", color: .indigo)
+                            }
+                            if resort.ikonPass != nil {
+                                PassBadge(passName: "Ikon", color: .orange)
+                            }
+                        }
+                    }
 
                     Button {
                         withAnimation { viewModel.removeResort(resort) }


### PR DESCRIPTION
## Summary
- Add snow depth and 48h forecast comparison rows to resort comparison view
- Add pass badges (Epic/Ikon) to resort headers in comparison
- Best-resort highlighting for depth (deepest) and forecast (most incoming snow)

## Test plan
- [ ] Compare 2+ resorts and verify snow depth and 48h forecast rows appear
- [ ] Verify pass badges show on resort headers
- [ ] Verify best values are highlighted in green
- [ ] Build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)