### PR TITLE
Show fresh snow per elevation in all-elevations summary

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -39,6 +39,14 @@
 
 | Feature | Date |
 |---------|------|
+| Add snow depth, forecast, and pass badges to resort comparison | 2026-02-22 |
+| Fix elevation display to respect user unit preferences (meters/feet) | 2026-02-22 |
+| Add pass badges to recommendation cards | 2026-02-22 |
+| Enhance share card with snow depth and 48h forecast stats | 2026-02-22 |
+| Extract PassBadge to shared component, reduce 30 LoC duplication | 2026-02-22 |
+| Optimize widget API calls (7 requests → 1-2 batch requests) | 2026-02-22 |
+| Fix elevation picker fallback when selected elevation has no data | 2026-02-22 |
+| Add accessibility labels to favorites quality indicators | 2026-02-22 |
 | Improve share text with snow score, depth, and forecast | 2026-02-22 |
 | Add storm badge to Favorites tab when significant snow predicted | 2026-02-22 |
 | Improve resort search to match country codes and pass types | 2026-02-22 |

--- a/ios/SnowTracker/SnowTracker/Sources/Views/ResortDetailView.swift
+++ b/ios/SnowTracker/SnowTracker/Sources/Views/ResortDetailView.swift
@@ -711,7 +711,7 @@ struct ResortDetailView: View {
 
                         Spacer()
 
-                        VStack(alignment: .trailing) {
+                        VStack(alignment: .trailing, spacing: 4) {
                             HStack(spacing: 4) {
                                 Image(systemName: condition.snowQuality.icon)
                                     .foregroundStyle(condition.snowQuality.color)
@@ -720,9 +720,19 @@ struct ResortDetailView: View {
                             }
                             .font(.subheadline)
 
-                            Text(condition.formattedTemperature(userPreferencesManager.preferredUnits))
-                                .font(.caption)
-                                .foregroundStyle(.secondary)
+                            HStack(spacing: 8) {
+                                Text(condition.formattedTemperature(userPreferencesManager.preferredUnits))
+                                if condition.freshSnowCm > 0 {
+                                    HStack(spacing: 2) {
+                                        Image(systemName: "snowflake")
+                                            .font(.caption2)
+                                        Text(WeatherCondition.formatSnowShort(condition.freshSnowCm, prefs: userPreferencesManager.preferredUnits))
+                                    }
+                                    .foregroundStyle(.cyan)
+                                }
+                            }
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
                         }
                     }
                     .padding(.vertical, 8)


### PR DESCRIPTION
## Summary
- Add fresh snow indicator (snowflake icon + amount) to each elevation row in the all-elevations summary card
- Only shows when fresh snow > 0cm, with cyan styling to match other fresh snow indicators
- Updates PROGRESS.md with recently shipped features

## Test plan
- [ ] View resort detail with snow at different elevations
- [ ] Verify fresh snow amounts appear next to temperature
- [ ] Verify no snowflake shows when fresh snow is 0
- [ ] Build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)