### PR TITLE
Add snow scores to widgets and show 5 resorts on large size

### DIFF
--- a/ios/SnowTrackerWidget/BestResortsWidget.swift
+++ b/ios/SnowTrackerWidget/BestResortsWidget.swift
@@ -146,12 +146,22 @@ struct BestResortsWidgetView: View {
         }
     }
 
+    private var resortCount: Int {
+        switch widgetFamily {
+        case .systemLarge: return 5
+        case .systemMedium: return 2
+        default: return 1
+        }
+    }
+
     var body: some View {
         switch widgetFamily {
         case .systemSmall:
             smallView
+        case .systemLarge:
+            largeView
         default:
-            mediumLargeView
+            mediumView
         }
     }
 
@@ -180,9 +190,16 @@ struct BestResortsWidgetView: View {
                     .lineLimit(1)
 
                 HStack(spacing: 4) {
-                    Image(systemName: resort.snowQuality.icon)
-                        .foregroundStyle(resort.snowQuality.color)
-                        .font(.title2)
+                    if let score = resort.snowScore {
+                        Text("\(score)")
+                            .font(.title2.weight(.bold))
+                            .fontDesign(.rounded)
+                            .foregroundStyle(resort.snowQuality.color)
+                    } else {
+                        Image(systemName: resort.snowQuality.icon)
+                            .foregroundStyle(resort.snowQuality.color)
+                            .font(.title2)
+                    }
                     Text(resort.snowQuality.displayName)
                         .font(.caption)
                         .fontWeight(.medium)
@@ -219,7 +236,7 @@ struct BestResortsWidgetView: View {
         .padding()
     }
 
-    private var mediumLargeView: some View {
+    private var mediumView: some View {
         VStack(alignment: .leading, spacing: 8) {
             HStack {
                 Image(systemName: "trophy.fill")
@@ -250,21 +267,11 @@ struct BestResortsWidgetView: View {
             } else {
                 ForEach(Array(entry.resorts.prefix(2).enumerated()), id: \.element.resortId) { index, resort in
                     HStack(spacing: 8) {
-                        // Rank badge
-                        ZStack {
-                            Circle()
-                                .fill(index == 0 ? Color.yellow : Color.gray.opacity(0.3))
-                                .frame(width: 24, height: 24)
-                            Text("\(index + 1)")
-                                .font(.caption)
-                                .fontWeight(.bold)
-                                .foregroundStyle(index == 0 ? .black : .primary)
-                        }
-
+                        rankBadge(index: index)
                         ResortConditionRow(resort: resort, unitPreferences: unitPreferences)
                     }
 
-                    if index < entry.resorts.prefix(2).count - 1 {
+                    if index < 1 {
                         Divider()
                     }
                 }
@@ -274,15 +281,76 @@ struct BestResortsWidgetView: View {
         }
         .padding()
     }
+
+    private var largeView: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            HStack {
+                Image(systemName: "trophy.fill")
+                    .foregroundStyle(.yellow)
+                    .font(.caption)
+                Text(regionTitle)
+                    .font(.caption)
+                    .fontWeight(.semibold)
+                    .foregroundStyle(.secondary)
+                Spacer()
+            }
+
+            if entry.resorts.isEmpty {
+                Spacer()
+                HStack {
+                    Spacer()
+                    VStack(spacing: 4) {
+                        Image(systemName: "cloud.snow")
+                            .font(.title2)
+                            .foregroundStyle(.secondary)
+                        Text("No data available")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                    Spacer()
+                }
+                Spacer()
+            } else {
+                ForEach(Array(entry.resorts.prefix(5).enumerated()), id: \.element.resortId) { index, resort in
+                    HStack(spacing: 8) {
+                        rankBadge(index: index)
+                        ResortConditionRow(resort: resort, unitPreferences: unitPreferences)
+                    }
+
+                    if index < entry.resorts.prefix(5).count - 1 {
+                        Divider()
+                    }
+                }
+            }
+
+            Spacer(minLength: 0)
+        }
+        .padding()
+    }
+
+    private func rankBadge(index: Int) -> some View {
+        ZStack {
+            Circle()
+                .fill(index == 0 ? Color.yellow : Color.gray.opacity(0.3))
+                .frame(width: 24, height: 24)
+            Text("\(index + 1)")
+                .font(.caption)
+                .fontWeight(.bold)
+                .foregroundStyle(index == 0 ? .black : .primary)
+        }
+    }
 }
 
 // MARK: - Preview
 
-#Preview(as: .systemMedium) {
+#Preview(as: .systemLarge) {
     BestResortsWidget()
 } timeline: {
     BestResortsEntry(date: .now, resorts: [
         ResortConditionData.sample,
-        ResortConditionData.sample2
+        ResortConditionData.sample2,
+        ResortConditionData.sample3,
+        ResortConditionData.sample4,
+        ResortConditionData.sample5
     ], region: .all)
 }

--- a/ios/SnowTrackerWidget/FavoriteResortsWidget.swift
+++ b/ios/SnowTrackerWidget/FavoriteResortsWidget.swift
@@ -15,7 +15,7 @@ struct FavoriteResortsWidget: Widget {
                 .containerBackground(.fill.tertiary, for: .widget)
         }
         .configurationDisplayName("Favorite Resorts")
-        .description("Snow conditions at your top 2 favorite resorts.")
+        .description("Snow conditions at your favorite resorts.")
         .supportedFamilies([.systemSmall, .systemMedium, .systemLarge])
     }
 }
@@ -83,8 +83,10 @@ struct FavoriteResortsWidgetView: View {
         switch widgetFamily {
         case .systemSmall:
             smallView
+        case .systemLarge:
+            listView(count: 5)
         default:
-            mediumLargeView
+            listView(count: 2)
         }
     }
 
@@ -108,9 +110,16 @@ struct FavoriteResortsWidgetView: View {
                     .lineLimit(1)
 
                 HStack(spacing: 4) {
-                    Image(systemName: resort.snowQuality.icon)
-                        .foregroundStyle(resort.snowQuality.color)
-                        .font(.title2)
+                    if let score = resort.snowScore {
+                        Text("\(score)")
+                            .font(.title2.weight(.bold))
+                            .fontDesign(.rounded)
+                            .foregroundStyle(resort.snowQuality.color)
+                    } else {
+                        Image(systemName: resort.snowQuality.icon)
+                            .foregroundStyle(resort.snowQuality.color)
+                            .font(.title2)
+                    }
                     Text(resort.snowQuality.displayName)
                         .font(.caption)
                         .fontWeight(.medium)
@@ -147,8 +156,8 @@ struct FavoriteResortsWidgetView: View {
         .padding()
     }
 
-    private var mediumLargeView: some View {
-        VStack(alignment: .leading, spacing: 8) {
+    private func listView(count: Int) -> some View {
+        VStack(alignment: .leading, spacing: count > 2 ? 6 : 8) {
             HStack {
                 Image(systemName: "heart.fill")
                     .foregroundStyle(.red)
@@ -176,9 +185,10 @@ struct FavoriteResortsWidgetView: View {
                 }
                 Spacer()
             } else {
-                ForEach(entry.resorts.prefix(2), id: \.resortId) { resort in
+                let displayResorts = Array(entry.resorts.prefix(count))
+                ForEach(Array(displayResorts.enumerated()), id: \.element.resortId) { index, resort in
                     ResortConditionRow(resort: resort, unitPreferences: unitPreferences)
-                    if resort.resortId != entry.resorts.prefix(2).last?.resortId {
+                    if index < displayResorts.count - 1 {
                         Divider()
                     }
                 }
@@ -192,11 +202,14 @@ struct FavoriteResortsWidgetView: View {
 
 // MARK: - Preview
 
-#Preview(as: .systemMedium) {
+#Preview(as: .systemLarge) {
     FavoriteResortsWidget()
 } timeline: {
     FavoriteResortsEntry(date: .now, resorts: [
         ResortConditionData.sample,
-        ResortConditionData.sample2
+        ResortConditionData.sample2,
+        ResortConditionData.sample3,
+        ResortConditionData.sample4,
+        ResortConditionData.sample5
     ])
 }

--- a/ios/SnowTrackerWidget/WidgetDataService.swift
+++ b/ios/SnowTrackerWidget/WidgetDataService.swift
@@ -33,7 +33,7 @@ final class WidgetDataService: @unchecked Sendable {
         }
 
         var components = URLComponents(url: baseURL.appendingPathComponent("api/v1/recommendations/best"), resolvingAgainstBaseURL: false)!
-        var queryItems = [URLQueryItem(name: "limit", value: "3")]
+        var queryItems = [URLQueryItem(name: "limit", value: "5")]
         if let region = region {
             queryItems.append(URLQueryItem(name: "region", value: region))
         }
@@ -63,6 +63,7 @@ final class WidgetDataService: @unchecked Sendable {
                     resortName: rec.resort.name,
                     location: "\(rec.resort.region), \(rec.resort.country)",
                     snowQuality: WidgetSnowQuality(rawValue: rec.snowQuality) ?? .unknown,
+                    snowScore: rec.snowScore,
                     temperature: rec.currentTempCelsius,
                     freshSnow: rec.freshSnowCm,
                     predictedSnow24h: rec.predictedSnow72hCm / 3.0 // Approximate 24h from 72h
@@ -109,6 +110,7 @@ final class WidgetDataService: @unchecked Sendable {
                 resortName: name.name,
                 location: name.location,
                 snowQuality: WidgetSnowQuality(rawValue: summary.overallQuality) ?? .unknown,
+                snowScore: summary.snowScore,
                 temperature: summary.temperatureC ?? 0,
                 freshSnow: summary.snowfallFreshCm ?? 0,
                 predictedSnow24h: (summary.predictedSnow48hCm ?? 0) / 2.0
@@ -127,7 +129,7 @@ final class WidgetDataService: @unchecked Sendable {
             return a.freshSnow > b.freshSnow
         }
 
-        return Array(sorted.prefix(2))
+        return Array(sorted.prefix(5))
     }
 
     // MARK: - Private Methods
@@ -226,6 +228,7 @@ private struct RecommendationsAPIResponse: Codable {
 private struct Recommendation: Codable {
     let resort: RecommendationResort
     let snowQuality: String
+    let snowScore: Int?
     let freshSnowCm: Double
     let predictedSnow72hCm: Double
     let currentTempCelsius: Double
@@ -233,6 +236,7 @@ private struct Recommendation: Codable {
     enum CodingKeys: String, CodingKey {
         case resort
         case snowQuality = "snow_quality"
+        case snowScore = "snow_score"
         case freshSnowCm = "fresh_snow_cm"
         case predictedSnow72hCm = "predicted_snow_72h_cm"
         case currentTempCelsius = "current_temp_celsius"
@@ -261,6 +265,7 @@ private struct BatchQualityResponse: Codable {
 
 private struct BatchSummary: Codable {
     let overallQuality: String
+    let snowScore: Int?
     let temperatureC: Double?
     let snowfallFreshCm: Double?
     let snowDepthCm: Double?
@@ -268,6 +273,7 @@ private struct BatchSummary: Codable {
 
     enum CodingKeys: String, CodingKey {
         case overallQuality = "overall_quality"
+        case snowScore = "snow_score"
         case temperatureC = "temperature_c"
         case snowfallFreshCm = "snowfall_fresh_cm"
         case snowDepthCm = "snow_depth_cm"

--- a/ios/SnowTrackerWidget/WidgetModels.swift
+++ b/ios/SnowTrackerWidget/WidgetModels.swift
@@ -57,6 +57,7 @@ struct ResortConditionData: Identifiable, Sendable {
     let resortName: String
     let location: String
     let snowQuality: WidgetSnowQuality
+    let snowScore: Int?
     let temperature: Double
     let freshSnow: Double
     let predictedSnow24h: Double
@@ -122,6 +123,7 @@ extension ResortConditionData {
         resortName: "Big White",
         location: "BC, Canada",
         snowQuality: .excellent,
+        snowScore: 92,
         temperature: -8,
         freshSnow: 20,
         predictedSnow24h: 15
@@ -132,8 +134,42 @@ extension ResortConditionData {
         resortName: "Vail",
         location: "CO, USA",
         snowQuality: .good,
+        snowScore: 72,
         temperature: -5,
         freshSnow: 12,
         predictedSnow24h: 8
+    )
+
+    static let sample3 = ResortConditionData(
+        resortId: "chamonix",
+        resortName: "Chamonix",
+        location: "Haute-Savoie, FR",
+        snowQuality: .good,
+        snowScore: 68,
+        temperature: -6,
+        freshSnow: 15,
+        predictedSnow24h: 10
+    )
+
+    static let sample4 = ResortConditionData(
+        resortId: "zermatt",
+        resortName: "Zermatt",
+        location: "Valais, CH",
+        snowQuality: .fair,
+        snowScore: 55,
+        temperature: -3,
+        freshSnow: 8,
+        predictedSnow24h: 5
+    )
+
+    static let sample5 = ResortConditionData(
+        resortId: "niseko",
+        resortName: "Niseko United",
+        location: "Hokkaido, JP",
+        snowQuality: .excellent,
+        snowScore: 95,
+        temperature: -12,
+        freshSnow: 35,
+        predictedSnow24h: 20
     )
 }

--- a/ios/SnowTrackerWidget/WidgetViews.swift
+++ b/ios/SnowTrackerWidget/WidgetViews.swift
@@ -24,6 +24,12 @@ struct ResortConditionRow: View {
 
             VStack(alignment: .trailing, spacing: 2) {
                 HStack(spacing: 4) {
+                    if let score = resort.snowScore {
+                        Text("\(score)")
+                            .font(.caption.weight(.bold))
+                            .fontDesign(.rounded)
+                            .foregroundStyle(resort.snowQuality.color)
+                    }
                     Image(systemName: resort.snowQuality.icon)
                         .foregroundStyle(resort.snowQuality.color)
                         .font(.caption)


### PR DESCRIPTION
## Summary
- Adds snow scores (0-100 from ML model) to both widget types — small widget shows numeric score, rows show score badge
- Large widgets now display up to 5 resorts instead of 2, making much better use of the space
- Backend: recommendations API now includes `snow_score` field (weighted across elevations, same as batch endpoint)

## Changes
- **Backend**: Added `snow_score` to `ResortRecommendation` dataclass and API response, computed via weighted elevation scores
- **Widget models**: Added `snowScore: Int?` to `ResortConditionData`, added sample data for 5 resorts
- **Widget data service**: Decodes `snow_score` from both recommendations and batch quality APIs, fetches 5 results
- **Widget views**: `ResortConditionRow` shows score badge, small views show score instead of icon when available
- **Best Resorts Widget**: Separate medium (2 resorts) and large (5 resorts) layouts with rank badges
- **Favorites Widget**: Parameterized list view supports 2 (medium) or 5 (large) resorts

## Test plan
- [x] iOS build succeeds
- [x] Backend recommendation service tests pass (16/16)
- [ ] Visual check on device: small, medium, large widget sizes
- [ ] Verify scores appear correctly from live API

🤖 Generated with [Claude Code](https://claude.com/claude-code)