### PR TITLE
Add streaming chat with SSE and tool tracing

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -223,6 +223,24 @@ jobs:
           echo "API handler Lambda updated"
         fi
 
+        # Deploy Chat Stream Lambda
+        CHAT_STREAM_LAMBDA=$(pulumi stack output chat_stream_lambda_name 2>/dev/null || echo "")
+        if [ -n "$CHAT_STREAM_LAMBDA" ]; then
+          echo "Deploying Chat stream Lambda: $CHAT_STREAM_LAMBDA"
+          aws lambda update-function-code \
+            --function-name "$CHAT_STREAM_LAMBDA" \
+            --s3-bucket "$S3_BUCKET" \
+            --s3-key "$S3_KEY" \
+            --region us-west-2
+          aws lambda wait function-updated --function-name "$CHAT_STREAM_LAMBDA" --region us-west-2
+          aws lambda update-function-configuration \
+            --function-name "$CHAT_STREAM_LAMBDA" \
+            --environment "Variables={ENVIRONMENT=${{ env.ENVIRONMENT }},CHAT_TABLE_NAME=snow-tracker-chat-${{ env.ENVIRONMENT }},RESULTS_BUCKET=snow-tracker-pulumi-state-us-west-2,AWS_REGION_NAME=us-west-2}" \
+            --region us-west-2
+          aws lambda wait function-updated --function-name "$CHAT_STREAM_LAMBDA" --region us-west-2
+          echo "Chat stream Lambda updated"
+        fi
+
         # Deploy Weather Processor Lambda
         WEATHER_LAMBDA=$(pulumi stack output weather_processor_lambda_name 2>/dev/null || echo "")
         if [ -n "$WEATHER_LAMBDA" ]; then

--- a/backend/src/handlers/chat_stream_handler.py
+++ b/backend/src/handlers/chat_stream_handler.py
@@ -1,0 +1,830 @@
+"""Streaming chat handler using Lambda Function URL with response streaming.
+
+Returns Server-Sent Events (SSE) for real-time chat updates:
+- {"type":"status","message":"..."} - progress updates
+- {"type":"tool_start","tool":"...","input":{}} - tool execution started
+- {"type":"tool_done","tool":"...","duration_ms":123} - tool execution completed
+- {"type":"text_delta","text":"..."} - streamed text chunk
+- {"type":"done","conversation_id":"...","message_id":"..."} - completion
+- {"type":"error","message":"..."} - error
+"""
+
+import json
+import logging
+import os
+import time
+import uuid
+
+import boto3
+from boto3.dynamodb.conditions import Key
+from botocore.exceptions import ClientError
+from ulid import ULID
+
+from services.chat_service import RESORT_ALIASES, SYSTEM_PROMPT, TOOL_DEFINITIONS
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
+
+# Bedrock retry settings
+BEDROCK_MAX_RETRIES = 3
+BEDROCK_BASE_DELAY = 1.0
+MAX_TOOL_ITERATIONS = 5
+
+
+def _sse(data: dict) -> str:
+    """Format a dict as an SSE event."""
+    return f"data: {json.dumps(data, default=str)}\n\n"
+
+
+def _get_dynamodb():
+    return boto3.resource(
+        "dynamodb", region_name=os.environ.get("AWS_REGION_NAME", "us-west-2")
+    )
+
+
+def _get_bedrock():
+    return boto3.client("bedrock-runtime", region_name="us-west-2")
+
+
+def _validate_jwt(token: str) -> str | None:
+    """Validate JWT and return user_id, or None if invalid."""
+    import jwt as pyjwt
+
+    jwt_secret = os.environ.get("JWT_SECRET_KEY", "dev-secret-change-in-prod")
+    try:
+        payload = pyjwt.decode(token, jwt_secret, algorithms=["HS256"])
+        return payload.get("sub")
+    except Exception:
+        return None
+
+
+def handler(event, response_stream, context):
+    """Lambda Function URL streaming handler for chat."""
+    # Set content type for SSE
+    response_stream.content_type = "text/event-stream"
+
+    try:
+        _handle_chat_stream(event, response_stream)
+    except Exception as e:
+        logger.error("Stream handler error: %s", e, exc_info=True)
+        response_stream.write(
+            _sse({"type": "error", "message": "Internal error"}).encode()
+        )
+    finally:
+        response_stream.close()
+
+
+def _handle_chat_stream(event, response_stream):
+    """Main streaming chat logic."""
+    # Handle CORS preflight
+    method = event.get("requestContext", {}).get("http", {}).get("method", "")
+    if method == "OPTIONS":
+        response_stream.write(_sse({"type": "done"}).encode())
+        return
+
+    # Parse request body
+    body_str = event.get("body", "{}")
+    if event.get("isBase64Encoded"):
+        import base64
+
+        body_str = base64.b64decode(body_str).decode()
+
+    try:
+        body = json.loads(body_str)
+    except json.JSONDecodeError:
+        response_stream.write(
+            _sse({"type": "error", "message": "Invalid JSON"}).encode()
+        )
+        return
+
+    user_message = body.get("message", "").strip()
+    conversation_id = body.get("conversation_id")
+
+    if not user_message:
+        response_stream.write(
+            _sse({"type": "error", "message": "Message is required"}).encode()
+        )
+        return
+
+    # Auth
+    headers = event.get("headers", {})
+    auth_header = headers.get("authorization", "")
+    user_id = None
+    if auth_header.startswith("Bearer "):
+        user_id = _validate_jwt(auth_header[7:])
+
+    if not user_id:
+        # Anonymous user - use IP
+        source_ip = (
+            event.get("requestContext", {}).get("http", {}).get("sourceIp", "unknown")
+        )
+        user_id = f"anon_{source_ip}"
+
+    # Send immediate status
+    response_stream.write(_sse({"type": "status", "message": "Thinking..."}).encode())
+
+    # Initialize services
+    dynamodb = _get_dynamodb()
+    bedrock = _get_bedrock()
+    chat_table_name = os.environ.get(
+        "CHAT_TABLE_NAME", f"snow-tracker-chat-{os.environ.get('ENVIRONMENT', 'prod')}"
+    )
+    chat_table = dynamodb.Table(chat_table_name)
+
+    # Generate conversation_id if new
+    if not conversation_id:
+        conversation_id = f"conv_{uuid.uuid4().hex[:12]}"
+
+    # Load history
+    history = _load_history(chat_table, conversation_id, user_id)
+    messages = _build_messages(history, user_message)
+
+    # Save user message
+    from datetime import UTC, datetime, timedelta
+
+    user_message_id = str(ULID())
+    now = datetime.now(UTC).isoformat()
+    is_first = len(history) == 0
+    title = user_message[:50] if is_first else None
+    _save_message(
+        chat_table,
+        conversation_id,
+        user_message_id,
+        user_id,
+        "user",
+        user_message,
+        now,
+        title,
+    )
+
+    # Auto-detect resorts
+    response_stream.write(
+        _sse({"type": "status", "message": "Analyzing your question..."}).encode()
+    )
+
+    context_data = _auto_detect_resorts_fast(user_message, dynamodb)
+
+    # Build system prompt
+    system_text = SYSTEM_PROMPT
+    if context_data:
+        system_text += (
+            "\n\n--- PRE-FETCHED DATA ---\n"
+            "The following resort data was auto-detected from the user's message. "
+            "Use this data directly instead of calling tools for these resorts. "
+            "You may still use tools for additional resorts or data not covered here.\n\n"
+            + context_data
+        )
+        response_stream.write(
+            _sse({"type": "status", "message": "Checking conditions..."}).encode()
+        )
+
+        # Try without tools first for speed
+        text = _call_bedrock_stream_no_tools(
+            bedrock, system_text, messages, response_stream
+        )
+        if text:
+            # Save and finish
+            assistant_id = str(ULID())
+            _save_message(
+                chat_table,
+                conversation_id,
+                assistant_id,
+                user_id,
+                "assistant",
+                text,
+                datetime.now(UTC).isoformat(),
+            )
+            response_stream.write(
+                _sse(
+                    {
+                        "type": "done",
+                        "conversation_id": conversation_id,
+                        "message_id": assistant_id,
+                    }
+                ).encode()
+            )
+            return
+
+    # Fall back to tool use loop with streaming
+    response_stream.write(
+        _sse({"type": "status", "message": "Looking up data..."}).encode()
+    )
+    text, tool_calls = _call_bedrock_with_tools_stream(
+        bedrock, system_text, messages, response_stream, dynamodb
+    )
+
+    # Save assistant message
+    assistant_id = str(ULID())
+    _save_message(
+        chat_table,
+        conversation_id,
+        assistant_id,
+        user_id,
+        "assistant",
+        text,
+        datetime.now(UTC).isoformat(),
+        tool_calls=tool_calls,
+    )
+
+    response_stream.write(
+        _sse(
+            {
+                "type": "done",
+                "conversation_id": conversation_id,
+                "message_id": assistant_id,
+            }
+        ).encode()
+    )
+
+
+def _call_bedrock_stream_no_tools(
+    bedrock, system_text, messages, response_stream
+) -> str | None:
+    """Call Bedrock with converse_stream (no tools) and stream text deltas."""
+    try:
+        response = bedrock.converse_stream(
+            modelId="us.anthropic.claude-sonnet-4-6",
+            system=[{"text": system_text}],
+            messages=messages,
+            inferenceConfig={"maxTokens": 2048, "temperature": 0.5},
+        )
+
+        stream = response.get("stream")
+        if not stream:
+            return None
+
+        text_parts = []
+        for event in stream:
+            if "contentBlockDelta" in event:
+                delta = event["contentBlockDelta"].get("delta", {})
+                if "text" in delta:
+                    chunk = delta["text"]
+                    text_parts.append(chunk)
+                    response_stream.write(
+                        _sse({"type": "text_delta", "text": chunk}).encode()
+                    )
+
+        return "".join(text_parts) if text_parts else None
+
+    except Exception as e:
+        logger.error("Bedrock stream error: %s", e)
+        return None
+
+
+def _call_bedrock_with_tools_stream(
+    bedrock, system_text, messages, response_stream, dynamodb
+):
+    """Call Bedrock with tool use loop, streaming progress and final text."""
+    all_tool_calls = []
+
+    for iteration in range(MAX_TOOL_ITERATIONS):
+        t_bedrock = time.monotonic()
+        try:
+            response = bedrock.converse(
+                modelId="us.anthropic.claude-sonnet-4-6",
+                system=[{"text": system_text}],
+                messages=messages,
+                toolConfig={"tools": TOOL_DEFINITIONS},
+                inferenceConfig={"maxTokens": 2048, "temperature": 0.5},
+            )
+        except ClientError as e:
+            error_code = e.response.get("Error", {}).get("Code", "")
+            if (
+                error_code == "ThrottlingException"
+                and iteration < BEDROCK_MAX_RETRIES - 1
+            ):
+                time.sleep(BEDROCK_BASE_DELAY * (2**iteration))
+                continue
+            response_stream.write(
+                _sse({"type": "error", "message": "AI service unavailable"}).encode()
+            )
+            return (
+                "I'm having trouble connecting to the AI service. Please try again.",
+                all_tool_calls or None,
+            )
+        except Exception as e:
+            logger.error("Bedrock error: %s", e)
+            return (
+                "I'm having trouble connecting to the AI service. Please try again.",
+                all_tool_calls or None,
+            )
+
+        bedrock_ms = int((time.monotonic() - t_bedrock) * 1000)
+        logger.info("Bedrock call #%d took %dms", iteration + 1, bedrock_ms)
+
+        output = response.get("output", {})
+        message = output.get("message", {})
+        content_blocks = message.get("content", [])
+        stop_reason = response.get("stopReason", "end_turn")
+
+        if stop_reason == "tool_use":
+            tool_use_blocks = [b for b in content_blocks if "toolUse" in b]
+            messages.append({"role": "assistant", "content": content_blocks})
+
+            tool_results = []
+            for tool_block in tool_use_blocks:
+                tool_use = tool_block["toolUse"]
+                tool_name = tool_use["name"]
+                tool_input = tool_use.get("input", {})
+                tool_use_id = tool_use["toolUseId"]
+
+                # Stream tool start
+                friendly = _tool_friendly_name(tool_name, tool_input)
+                response_stream.write(
+                    _sse(
+                        {
+                            "type": "tool_start",
+                            "tool": tool_name,
+                            "input": tool_input,
+                            "message": friendly,
+                        }
+                    ).encode()
+                )
+
+                t_tool = time.monotonic()
+                try:
+                    result = _execute_tool(tool_name, tool_input, dynamodb)
+                    tool_ms = int((time.monotonic() - t_tool) * 1000)
+                    logger.info("Tool %s took %dms", tool_name, tool_ms)
+
+                    response_stream.write(
+                        _sse(
+                            {
+                                "type": "tool_done",
+                                "tool": tool_name,
+                                "duration_ms": tool_ms,
+                            }
+                        ).encode()
+                    )
+
+                    all_tool_calls.append(
+                        {
+                            "tool": tool_name,
+                            "input": tool_input,
+                            "success": True,
+                            "duration_ms": tool_ms,
+                        }
+                    )
+                    tool_results.append(
+                        {
+                            "toolResult": {
+                                "toolUseId": tool_use_id,
+                                "content": [{"json": result}],
+                            }
+                        }
+                    )
+                except Exception as e:
+                    tool_ms = int((time.monotonic() - t_tool) * 1000)
+                    logger.error("Tool %s failed after %dms: %s", tool_name, tool_ms, e)
+                    all_tool_calls.append(
+                        {
+                            "tool": tool_name,
+                            "input": tool_input,
+                            "success": False,
+                            "duration_ms": tool_ms,
+                        }
+                    )
+                    tool_results.append(
+                        {
+                            "toolResult": {
+                                "toolUseId": tool_use_id,
+                                "content": [{"text": f"Error: {e}"}],
+                                "status": "error",
+                            }
+                        }
+                    )
+
+            messages.append({"role": "user", "content": tool_results})
+
+            # Stream the final response using converse_stream
+            if iteration < MAX_TOOL_ITERATIONS - 1:
+                # Try streaming the next response
+                try:
+                    stream_resp = bedrock.converse_stream(
+                        modelId="us.anthropic.claude-sonnet-4-6",
+                        system=[{"text": system_text}],
+                        messages=messages,
+                        toolConfig={"tools": TOOL_DEFINITIONS},
+                        inferenceConfig={"maxTokens": 2048, "temperature": 0.5},
+                    )
+                    stream = stream_resp.get("stream")
+                    if stream:
+                        text_parts = []
+                        has_tool_use = False
+                        for evt in stream:
+                            if "contentBlockDelta" in evt:
+                                delta = evt["contentBlockDelta"].get("delta", {})
+                                if "text" in delta:
+                                    chunk = delta["text"]
+                                    text_parts.append(chunk)
+                                    response_stream.write(
+                                        _sse(
+                                            {"type": "text_delta", "text": chunk}
+                                        ).encode()
+                                    )
+                            elif "contentBlockStart" in evt:
+                                start = evt["contentBlockStart"].get("start", {})
+                                if "toolUse" in start:
+                                    has_tool_use = True
+                                    break
+
+                        if text_parts and not has_tool_use:
+                            return "".join(text_parts), all_tool_calls or None
+
+                        # If we hit another tool_use, fall through to continue the loop
+                        if has_tool_use:
+                            # We need to collect the rest of the stream to get tool calls
+                            # Fall back to non-streaming for this iteration
+                            continue
+                except Exception as e:
+                    logger.warning("Stream fallback: %s", e)
+
+            continue
+
+        # Final text response
+        text_parts = [b["text"] for b in content_blocks if "text" in b]
+        text = (
+            "\n".join(text_parts) if text_parts else "I couldn't generate a response."
+        )
+
+        # Stream the text
+        response_stream.write(_sse({"type": "text_delta", "text": text}).encode())
+        return text, all_tool_calls or None
+
+    return "I'm having trouble processing your request.", all_tool_calls or None
+
+
+def _tool_friendly_name(tool_name: str, tool_input: dict) -> str:
+    """Return a user-friendly description of a tool call."""
+    resort_id = tool_input.get("resort_id", "")
+    resort_name = resort_id.replace("-", " ").title() if resort_id else ""
+
+    names = {
+        "get_resort_conditions": f"Checking conditions at {resort_name}..."
+        if resort_name
+        else "Checking conditions...",
+        "search_resorts": f'Searching for "{tool_input.get("query", "")}"...',
+        "get_nearby_resorts": "Finding nearby resorts...",
+        "get_resort_forecast": f"Getting forecast for {resort_name}..."
+        if resort_name
+        else "Getting forecast...",
+        "get_best_conditions": "Finding best conditions...",
+        "get_resort_info": f"Looking up {resort_name}..."
+        if resort_name
+        else "Looking up resort info...",
+        "get_condition_reports": f"Checking reports for {resort_name}..."
+        if resort_name
+        else "Checking reports...",
+        "get_snow_history": f"Getting history for {resort_name}..."
+        if resort_name
+        else "Getting snow history...",
+        "compare_resorts": "Comparing resorts...",
+    }
+    return names.get(tool_name, f"Running {tool_name}...")
+
+
+def _auto_detect_resorts_fast(user_message: str, dynamodb) -> str | None:
+    """Quick resort detection using aliases only (no DB scan)."""
+    import re
+
+    message_lower = user_message.lower()
+    detected_ids: set[str] = set()
+
+    for alias, resort_id in RESORT_ALIASES.items():
+        pattern = r"\b" + re.escape(alias) + r"\b"
+        if re.search(pattern, message_lower):
+            detected_ids.add(resort_id)
+
+    if not detected_ids:
+        return None
+
+    resort_ids = list(detected_ids)[:3]
+    env = os.environ.get("ENVIRONMENT", "prod")
+    conditions_table = dynamodb.Table(f"snow-tracker-weather-conditions-{env}")
+    resorts_table = dynamodb.Table(f"snow-tracker-resorts-{env}")
+
+    context_parts = []
+    for resort_id in resort_ids:
+        try:
+            # Get resort name
+            resort_resp = resorts_table.get_item(Key={"resort_id": resort_id})
+            resort = resort_resp.get("Item", {})
+            resort_name = resort.get("name", resort_id)
+
+            # Get conditions
+            cond_resp = conditions_table.query(
+                KeyConditionExpression=Key("resort_id").eq(resort_id),
+                ScanIndexForward=False,
+                Limit=3,
+            )
+            conditions = cond_resp.get("Items", [])
+
+            if conditions:
+                elevations = {}
+                for c in conditions:
+                    level = c.get("elevation_level", "unknown")
+                    elevations[level] = {
+                        "temperature_celsius": _to_float(c.get("current_temp_celsius")),
+                        "snowfall_24h_cm": _to_float(c.get("snowfall_24h_cm")),
+                        "snow_quality": c.get("snow_quality", "unknown"),
+                        "quality_score": _to_float(c.get("quality_score")),
+                        "fresh_snow_cm": _to_float(c.get("fresh_snow_cm")),
+                        "snow_depth_cm": _to_float(c.get("snow_depth_cm")),
+                        "wind_speed_kmh": _to_float(c.get("wind_speed_kmh")),
+                    }
+                data = {"resort_id": resort_id, "elevations": elevations}
+                context_parts.append(
+                    f"Resort: {resort_name} ({resort_id})\n"
+                    f"Conditions: {json.dumps(data, default=str)}\n"
+                )
+        except Exception as e:
+            logger.warning("Auto-detect error for %s: %s", resort_id, e)
+
+    return "\n".join(context_parts) if context_parts else None
+
+
+def _to_float(val) -> float | None:
+    if val is None:
+        return None
+    try:
+        return float(val)
+    except (TypeError, ValueError):
+        return None
+
+
+def _execute_tool(tool_name: str, tool_input: dict, dynamodb) -> dict:
+    """Execute a tool directly using DynamoDB (no service layer for speed)."""
+    env = os.environ.get("ENVIRONMENT", "prod")
+
+    if tool_name == "get_resort_conditions":
+        resort_id = tool_input.get("resort_id", "")
+        if not resort_id:
+            return {"error": "Missing resort_id"}
+        table = dynamodb.Table(f"snow-tracker-weather-conditions-{env}")
+        resp = table.query(
+            KeyConditionExpression=Key("resort_id").eq(resort_id),
+            ScanIndexForward=False,
+            Limit=3,
+        )
+        items = resp.get("Items", [])
+        if not items:
+            return {"error": f"No conditions for '{resort_id}'"}
+        elevations = {}
+        for c in items:
+            level = c.get("elevation_level", "unknown")
+            elevations[level] = {
+                "temperature_celsius": _to_float(c.get("current_temp_celsius")),
+                "snowfall_24h_cm": _to_float(c.get("snowfall_24h_cm")),
+                "snow_quality": c.get("snow_quality", "unknown"),
+                "quality_score": _to_float(c.get("quality_score")),
+                "fresh_snow_cm": _to_float(c.get("fresh_snow_cm")),
+                "snow_depth_cm": _to_float(c.get("snow_depth_cm")),
+                "wind_speed_kmh": _to_float(c.get("wind_speed_kmh")),
+            }
+        return {"resort_id": resort_id, "elevations": elevations}
+
+    elif tool_name == "search_resorts":
+        query = tool_input.get("query", "").lower()
+        if not query:
+            return {"error": "Missing query"}
+        table = dynamodb.Table(f"snow-tracker-resorts-{env}")
+        resp = table.scan()
+        results = []
+        for r in resp.get("Items", []):
+            name = r.get("name", "").lower()
+            region = r.get("region", "").lower()
+            country = r.get("country", "").lower()
+            if query in name or query in region or query in country:
+                results.append(
+                    {
+                        "resort_id": r["resort_id"],
+                        "name": r.get("name"),
+                        "country": r.get("country"),
+                        "region": r.get("region"),
+                    }
+                )
+        return {"results": results[:20], "count": len(results)}
+
+    elif tool_name == "get_best_conditions":
+        # Read from static JSON in S3
+        try:
+            s3 = boto3.client("s3", region_name="us-west-2")
+            bucket = os.environ.get(
+                "RESULTS_BUCKET", "snow-tracker-pulumi-state-us-west-2"
+            )
+            key = f"static-json/{env}/best-conditions.json"
+            resp = s3.get_object(Bucket=bucket, Key=key)
+            data = json.loads(resp["Body"].read())
+            limit = min(tool_input.get("limit", 10), 20)
+            return {"results": data[:limit], "count": len(data[:limit])}
+        except Exception as e:
+            logger.warning("Best conditions from S3 failed: %s", e)
+            return {"error": "Could not fetch best conditions"}
+
+    elif tool_name == "get_resort_info":
+        resort_id = tool_input.get("resort_id", "")
+        if not resort_id:
+            return {"error": "Missing resort_id"}
+        table = dynamodb.Table(f"snow-tracker-resorts-{env}")
+        resp = table.get_item(Key={"resort_id": resort_id})
+        item = resp.get("Item")
+        if not item:
+            return {"error": f"Resort '{resort_id}' not found"}
+        return {
+            "resort_id": item["resort_id"],
+            "name": item.get("name"),
+            "country": item.get("country"),
+            "region": item.get("region"),
+            "timezone": item.get("timezone"),
+        }
+
+    elif tool_name == "get_resort_forecast":
+        resort_id = tool_input.get("resort_id", "")
+        if not resort_id:
+            return {"error": "Missing resort_id"}
+        # Use static forecast JSON if available
+        try:
+            s3 = boto3.client("s3", region_name="us-west-2")
+            bucket = os.environ.get(
+                "RESULTS_BUCKET", "snow-tracker-pulumi-state-us-west-2"
+            )
+            key = f"static-json/{env}/resort-{resort_id}.json"
+            resp = s3.get_object(Bucket=bucket, Key=key)
+            data = json.loads(resp["Body"].read())
+            return {"resort_id": resort_id, "forecast": data.get("forecast", data)}
+        except Exception:
+            return {"resort_id": resort_id, "forecast": "Not available"}
+
+    elif tool_name == "get_snow_history":
+        resort_id = tool_input.get("resort_id", "")
+        if not resort_id:
+            return {"error": "Missing resort_id"}
+        table = dynamodb.Table(f"snow-tracker-daily-history-{env}")
+        resp = table.query(
+            KeyConditionExpression=Key("resort_id").eq(resort_id),
+            ScanIndexForward=False,
+            Limit=7,
+        )
+        items = resp.get("Items", [])
+        items.reverse()
+        total = sum(float(r.get("snowfall_24h_cm", 0)) for r in items)
+        return {
+            "resort_id": resort_id,
+            "recent_days": [
+                {
+                    "date": r.get("date"),
+                    "snowfall_24h_cm": _to_float(r.get("snowfall_24h_cm")),
+                    "snow_depth_cm": _to_float(r.get("snow_depth_cm")),
+                    "snow_quality": r.get("snow_quality"),
+                }
+                for r in items
+            ],
+            "total_snowfall_cm": round(total, 1),
+        }
+
+    elif tool_name == "get_condition_reports":
+        resort_id = tool_input.get("resort_id", "")
+        if not resort_id:
+            return {"error": "Missing resort_id"}
+        table = dynamodb.Table(f"snow-tracker-condition-reports-{env}")
+        resp = table.query(
+            KeyConditionExpression=Key("resort_id").eq(resort_id),
+            ScanIndexForward=False,
+            Limit=5,
+        )
+        items = resp.get("Items", [])
+        return {
+            "resort_id": resort_id,
+            "reports": [
+                {
+                    "condition_type": r.get("condition_type"),
+                    "score": _to_float(r.get("score")),
+                    "comment": r.get("comment"),
+                    "created_at": r.get("created_at"),
+                }
+                for r in items
+            ],
+        }
+
+    elif tool_name == "compare_resorts":
+        resort_ids = tool_input.get("resort_ids", [])
+        if len(resort_ids) < 2:
+            return {"error": "Need at least 2 resorts"}
+        results = []
+        for rid in resort_ids[:4]:
+            cond = _execute_tool("get_resort_conditions", {"resort_id": rid}, dynamodb)
+            results.append(cond)
+        return {"comparison": results}
+
+    elif tool_name == "get_nearby_resorts":
+        lat = tool_input.get("latitude")
+        lon = tool_input.get("longitude")
+        if lat is None or lon is None:
+            return {"error": "Missing coordinates"}
+        # Scan resorts and compute distances
+        import math
+
+        table = dynamodb.Table(f"snow-tracker-resorts-{env}")
+        resp = table.scan()
+        items = resp.get("Items", [])
+        nearby = []
+        for r in items:
+            eps = r.get("elevation_points", [])
+            if not eps:
+                continue
+            ep = eps[0]
+            rlat = float(ep.get("latitude", 0))
+            rlon = float(ep.get("longitude", 0))
+            dist = _haversine(lat, lon, rlat, rlon)
+            radius = tool_input.get("radius_km", 200)
+            if dist <= radius:
+                nearby.append(
+                    {
+                        "resort_id": r["resort_id"],
+                        "name": r.get("name"),
+                        "country": r.get("country"),
+                        "distance_km": round(dist, 1),
+                    }
+                )
+        nearby.sort(key=lambda x: x["distance_km"])
+        return {"results": nearby[:20], "count": len(nearby)}
+
+    return {"error": f"Unknown tool: {tool_name}"}
+
+
+def _haversine(lat1, lon1, lat2, lon2):
+    """Calculate distance in km between two points."""
+    import math
+
+    R = 6371
+    dlat = math.radians(lat2 - lat1)
+    dlon = math.radians(lon2 - lon1)
+    a = (
+        math.sin(dlat / 2) ** 2
+        + math.cos(math.radians(lat1))
+        * math.cos(math.radians(lat2))
+        * math.sin(dlon / 2) ** 2
+    )
+    return R * 2 * math.asin(math.sqrt(a))
+
+
+def _load_history(chat_table, conversation_id, user_id):
+    """Load last 20 messages."""
+    try:
+        resp = chat_table.query(
+            KeyConditionExpression=Key("conversation_id").eq(conversation_id),
+            ScanIndexForward=False,
+            Limit=20,
+        )
+        items = resp.get("Items", [])
+        if items and items[0].get("user_id") != user_id:
+            return []
+        items.reverse()
+        return items
+    except Exception:
+        return []
+
+
+def _build_messages(history, user_message):
+    """Build Bedrock messages from history."""
+    messages = []
+    for item in history:
+        role = item.get("role", "user")
+        content = item.get("content", "")
+        if role in ("user", "assistant") and content:
+            messages.append({"role": role, "content": [{"text": content}]})
+    messages.append({"role": "user", "content": [{"text": user_message}]})
+    return messages
+
+
+def _save_message(
+    chat_table,
+    conversation_id,
+    message_id,
+    user_id,
+    role,
+    content,
+    created_at,
+    title=None,
+    tool_calls=None,
+):
+    """Save message to DynamoDB."""
+    from datetime import UTC, datetime, timedelta
+
+    item = {
+        "conversation_id": conversation_id,
+        "message_id": message_id,
+        "user_id": user_id,
+        "role": role,
+        "content": content,
+        "created_at": created_at,
+        "expires_at": int((datetime.now(UTC) + timedelta(days=30)).timestamp()),
+    }
+    if title:
+        item["title"] = title
+    if tool_calls:
+        item["tool_calls"] = tool_calls
+    try:
+        chat_table.put_item(Item=item)
+    except Exception as e:
+        logger.error("Error saving message: %s", e)

--- a/backend/src/services/chat_service.py
+++ b/backend/src/services/chat_service.py
@@ -675,7 +675,7 @@ class ChatService:
                     system=[{"text": system_text}],
                     messages=messages,
                     toolConfig={"tools": TOOL_DEFINITIONS},
-                    inferenceConfig={"maxTokens": 1024, "temperature": 0.5},
+                    inferenceConfig={"maxTokens": 2048, "temperature": 0.5},
                 )
             except ClientError as e:
                 error_code = e.response.get("Error", {}).get("Code", "")
@@ -722,7 +722,7 @@ class ChatService:
                     modelId="us.anthropic.claude-sonnet-4-6",
                     system=[{"text": system_text}],
                     messages=messages,
-                    inferenceConfig={"maxTokens": 1024, "temperature": 0.5},
+                    inferenceConfig={"maxTokens": 2048, "temperature": 0.5},
                 )
             except ClientError as e:
                 error_code = e.response.get("Error", {}).get("Code", "")
@@ -783,8 +783,11 @@ class ChatService:
                 if text_parts:
                     return "\n".join(text_parts), None
 
-        for _iteration in range(MAX_TOOL_ITERATIONS):
+        for iteration in range(MAX_TOOL_ITERATIONS):
+            t_bedrock = time.monotonic()
             response = self._invoke_bedrock(system_text, messages)
+            bedrock_ms = int((time.monotonic() - t_bedrock) * 1000)
+            logger.info("Bedrock call #%d took %dms", iteration + 1, bedrock_ms)
             if response is None:
                 return (
                     "I'm having trouble connecting to the AI service. Please try again.",
@@ -801,7 +804,6 @@ class ChatService:
             if stop_reason == "tool_use":
                 # Process tool calls
                 tool_use_blocks = [b for b in content_blocks if "toolUse" in b]
-                text_blocks = [b for b in content_blocks if "text" in b]
 
                 # Add assistant message with tool use to conversation
                 messages.append({"role": "assistant", "content": content_blocks})
@@ -814,17 +816,22 @@ class ChatService:
                     tool_input = tool_use.get("input", {})
                     tool_use_id = tool_use["toolUseId"]
 
-                    logger.info(
-                        "Executing tool: %s with input: %s", tool_name, tool_input
-                    )
-
+                    t_tool = time.monotonic()
                     try:
                         result = self._execute_tool(tool_name, tool_input)
+                        tool_ms = int((time.monotonic() - t_tool) * 1000)
+                        logger.info(
+                            "Tool %s took %dms (input: %s)",
+                            tool_name,
+                            tool_ms,
+                            tool_input,
+                        )
                         all_tool_calls.append(
                             {
                                 "tool": tool_name,
                                 "input": tool_input,
                                 "success": True,
+                                "duration_ms": tool_ms,
                             }
                         )
                         tool_results.append(
@@ -836,13 +843,17 @@ class ChatService:
                             }
                         )
                     except Exception as e:
-                        logger.error("Tool execution error for %s: %s", tool_name, e)
+                        tool_ms = int((time.monotonic() - t_tool) * 1000)
+                        logger.error(
+                            "Tool %s failed after %dms: %s", tool_name, tool_ms, e
+                        )
                         all_tool_calls.append(
                             {
                                 "tool": tool_name,
                                 "input": tool_input,
                                 "success": False,
                                 "error": str(e),
+                                "duration_ms": tool_ms,
                             }
                         )
                         tool_results.append(

--- a/backend/tests/test_chat_service.py
+++ b/backend/tests/test_chat_service.py
@@ -270,7 +270,7 @@ class TestChat:
         assert call_kwargs["modelId"] == "us.anthropic.claude-sonnet-4-6"
         assert call_kwargs["system"] == [{"text": SYSTEM_PROMPT}]
         assert call_kwargs["toolConfig"]["tools"] == TOOL_DEFINITIONS
-        assert call_kwargs["inferenceConfig"]["maxTokens"] == 1024
+        assert call_kwargs["inferenceConfig"]["maxTokens"] == 2048
         assert call_kwargs["inferenceConfig"]["temperature"] == 0.5
 
     def test_conversation_history_loaded(

--- a/infrastructure/__main__.py
+++ b/infrastructure/__main__.py
@@ -1241,6 +1241,53 @@ def get_conditions(resort_id, headers):
     opts=pulumi.ResourceOptions(depends_on=[lambda_role, log_group]),
 )
 
+# ---- Chat Streaming Lambda (Function URL with response streaming) ----
+chat_stream_log_group = aws.cloudwatch.LogGroup(
+    f"{app_name}-chat-stream-logs-{environment}",
+    name=f"/aws/lambda/{app_name}-chat-stream-{environment}",
+    retention_in_days=14,
+    tags=tags,
+)
+
+chat_stream_lambda = aws.lambda_.Function(
+    f"{app_name}-chat-stream-{environment}",
+    name=f"{app_name}-chat-stream-{environment}",
+    role=lambda_role.arn,
+    handler="handlers.chat_stream_handler.handler",
+    runtime="python3.12",
+    timeout=90,
+    memory_size=512,
+    code=pulumi.AssetArchive(
+        {"placeholder.py": pulumi.StringAsset("# placeholder - deployed via CI")}
+    ),
+    environment=aws.lambda_.FunctionEnvironmentArgs(
+        variables={
+            "ENVIRONMENT": environment,
+            "CHAT_TABLE_NAME": f"{app_name}-chat-{environment}",
+            "RESULTS_BUCKET": "snow-tracker-pulumi-state-us-west-2",
+            "AWS_REGION_NAME": aws_region,
+        }
+    ),
+    tags=tags,
+    opts=pulumi.ResourceOptions(depends_on=[lambda_role, chat_stream_log_group]),
+)
+
+chat_stream_url = aws.lambda_.FunctionUrl(
+    f"{app_name}-chat-stream-url-{environment}",
+    function_name=chat_stream_lambda.name,
+    authorization_type="NONE",
+    invoke_mode="RESPONSE_STREAM",
+    cors=aws.lambda_.FunctionUrlCorsArgs(
+        allow_origins=["*"],
+        allow_methods=["POST", "OPTIONS"],
+        allow_headers=["Content-Type", "Authorization"],
+        max_age=3600,
+    ),
+)
+
+pulumi.export("chat_stream_url", chat_stream_url.function_url)
+pulumi.export("chat_stream_lambda_name", chat_stream_lambda.name)
+
 # Permission for API Gateway to invoke the API handler Lambda
 api_handler_permission = aws.lambda_.Permission(
     f"{app_name}-api-handler-permission-{environment}",

--- a/web/src/components/chat/ChatWindow.tsx
+++ b/web/src/components/chat/ChatWindow.tsx
@@ -1,19 +1,28 @@
 import { useEffect, useRef } from 'react'
-import { Snowflake, MessageCircle } from 'lucide-react'
+import { Snowflake, MessageCircle, Loader2, Wrench } from 'lucide-react'
 import type { ChatMessage as ChatMessageType } from '../../api/types'
 import { ChatMessage, TypingIndicator } from './ChatMessage'
 
 interface ChatWindowProps {
   messages: ChatMessageType[]
   isLoading: boolean
+  statusMessage?: string | null
+  activeTools?: string[]
+  onSuggestionClick?: (text: string) => void
 }
 
-export function ChatWindow({ messages, isLoading }: ChatWindowProps) {
+export function ChatWindow({
+  messages,
+  isLoading,
+  statusMessage,
+  activeTools,
+  onSuggestionClick,
+}: ChatWindowProps) {
   const bottomRef = useRef<HTMLDivElement>(null)
 
   useEffect(() => {
     bottomRef.current?.scrollIntoView({ behavior: 'smooth' })
-  }, [messages, isLoading])
+  }, [messages, isLoading, statusMessage])
 
   if (messages.length === 0 && !isLoading) {
     return (
@@ -38,6 +47,7 @@ export function ChatWindow({ messages, isLoading }: ChatWindowProps) {
             ].map((suggestion) => (
               <button
                 key={suggestion}
+                onClick={() => onSuggestionClick?.(suggestion)}
                 className="text-left px-3 py-2.5 rounded-lg border border-gray-200 text-sm text-gray-600 hover:bg-gray-50 hover:border-gray-300 transition-colors"
               >
                 <MessageCircle className="w-3.5 h-3.5 inline-block mr-1.5 opacity-50" />
@@ -55,7 +65,30 @@ export function ChatWindow({ messages, isLoading }: ChatWindowProps) {
       {messages.map((message) => (
         <ChatMessage key={message.message_id} message={message} />
       ))}
-      {isLoading && <TypingIndicator />}
+      {isLoading && !statusMessage && activeTools?.length === 0 && <TypingIndicator />}
+      {isLoading && (statusMessage || (activeTools && activeTools.length > 0)) && (
+        <div className="flex justify-start">
+          <div className="bg-white rounded-2xl rounded-tl-sm px-4 py-3 shadow-sm border border-gray-100 max-w-sm">
+            <div className="flex items-center gap-2 text-sm text-gray-500">
+              <Loader2 className="w-4 h-4 animate-spin text-blue-500" />
+              <span>{statusMessage || 'Thinking...'}</span>
+            </div>
+            {activeTools && activeTools.length > 0 && (
+              <div className="flex flex-wrap gap-1.5 mt-2">
+                {activeTools.map((tool) => (
+                  <span
+                    key={tool}
+                    className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full bg-blue-50 text-blue-600 text-xs font-medium"
+                  >
+                    <Wrench className="w-3 h-3" />
+                    {tool.replace(/_/g, ' ')}
+                  </span>
+                ))}
+              </div>
+            )}
+          </div>
+        </div>
+      )}
       <div ref={bottomRef} />
     </div>
   )

--- a/web/src/hooks/useChat.ts
+++ b/web/src/hooks/useChat.ts
@@ -1,7 +1,9 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { api, ApiError } from '../api/client'
-import type { ChatMessage, ChatResponse } from '../api/types'
-import { useState, useCallback } from 'react'
+import type { ChatMessage } from '../api/types'
+import { useState, useCallback, useRef } from 'react'
+
+const STREAM_URL = import.meta.env.VITE_CHAT_STREAM_URL || ''
 
 export function useConversations() {
   return useQuery({
@@ -20,27 +22,6 @@ export function useConversationMessages(conversationId: string | undefined) {
   })
 }
 
-export function useSendMessage() {
-  const queryClient = useQueryClient()
-
-  return useMutation({
-    mutationFn: ({
-      message,
-      conversationId,
-    }: {
-      message: string
-      conversationId?: string
-    }) => api.sendChatMessage(message, conversationId),
-    onSuccess: (data: ChatResponse) => {
-      // Invalidate conversation list and the specific conversation
-      queryClient.invalidateQueries({ queryKey: ['conversations'] })
-      queryClient.invalidateQueries({
-        queryKey: ['conversation', data.conversation_id],
-      })
-    },
-  })
-}
-
 export function useDeleteConversation() {
   const queryClient = useQueryClient()
 
@@ -52,16 +33,32 @@ export function useDeleteConversation() {
   })
 }
 
-/** Combined hook for managing a chat session */
+interface StreamEvent {
+  type: 'status' | 'tool_start' | 'tool_done' | 'text_delta' | 'done' | 'error'
+  message?: string
+  tool?: string
+  input?: Record<string, unknown>
+  duration_ms?: number
+  text?: string
+  conversation_id?: string
+  message_id?: string
+}
+
+/** Combined hook for managing a chat session with streaming */
 export function useChatSession(initialConversationId?: string) {
   const [conversationId, setConversationId] = useState<string | undefined>(
     initialConversationId,
   )
   const [messages, setMessages] = useState<ChatMessage[]>([])
+  const [isLoading, setIsLoading] = useState(false)
   const [isRateLimited, setIsRateLimited] = useState(false)
+  const [statusMessage, setStatusMessage] = useState<string | null>(null)
+  const [activeTools, setActiveTools] = useState<string[]>([])
+  const [error, setError] = useState<Error | null>(null)
+  const queryClient = useQueryClient()
+  const abortRef = useRef<AbortController | null>(null)
 
   const conversationQuery = useConversationMessages(conversationId)
-  const sendMutation = useSendMessage()
 
   // Sync messages from server
   const serverMessages = conversationQuery.data
@@ -85,19 +82,28 @@ export function useChatSession(initialConversationId?: string) {
       }
       setMessages((prev) => [...prev, userMessage])
       setIsRateLimited(false)
+      setError(null)
+      setIsLoading(true)
+      setStatusMessage(null)
+      setActiveTools([])
 
+      // Try streaming if URL is configured
+      if (STREAM_URL) {
+        try {
+          await sendMessageStream(content, userMessage)
+          return
+        } catch (err) {
+          // Fall back to non-streaming on stream failure
+          console.warn('Stream failed, falling back to REST:', err)
+        }
+      }
+
+      // Fallback: non-streaming REST call
       try {
-        const response = await sendMutation.mutateAsync({
-          message: content,
-          conversationId,
-        })
-
-        // Update conversation ID if this was a new conversation
+        const response = await api.sendChatMessage(content, conversationId)
         if (!conversationId) {
           setConversationId(response.conversation_id)
         }
-
-        // Add assistant message
         const assistantMessage: ChatMessage = {
           role: 'assistant',
           content: response.response,
@@ -105,22 +111,146 @@ export function useChatSession(initialConversationId?: string) {
           created_at: new Date().toISOString(),
         }
         setMessages((prev) => [...prev, assistantMessage])
-      } catch (error) {
-        if (error instanceof ApiError && error.status === 429) {
+        queryClient.invalidateQueries({ queryKey: ['conversations'] })
+      } catch (err) {
+        if (err instanceof ApiError && err.status === 429) {
           setIsRateLimited(true)
         }
-        // Remove optimistic message on error
         setMessages((prev) => prev.filter((m) => m.message_id !== userMessage.message_id))
-        throw error
+        setError(err instanceof Error ? err : new Error('Failed to send message'))
+        throw err
+      } finally {
+        setIsLoading(false)
+        setStatusMessage(null)
+        setActiveTools([])
       }
     },
-    [conversationId, sendMutation],
+    [conversationId, queryClient],
+  )
+
+  const sendMessageStream = useCallback(
+    async (content: string, _userMessage: ChatMessage) => {
+      const controller = new AbortController()
+      abortRef.current = controller
+
+      const token = localStorage.getItem('snow_access_token')
+      const headers: Record<string, string> = { 'Content-Type': 'application/json' }
+      if (token) headers['Authorization'] = `Bearer ${token}`
+
+      const response = await fetch(STREAM_URL, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify({
+          message: content,
+          conversation_id: conversationId,
+        }),
+        signal: controller.signal,
+      })
+
+      if (!response.ok || !response.body) {
+        throw new Error(`Stream request failed: ${response.status}`)
+      }
+
+      const reader = response.body.getReader()
+      const decoder = new TextDecoder()
+      let buffer = ''
+      let assistantText = ''
+      let assistantId = ''
+      let newConversationId = ''
+
+      // Add a placeholder assistant message immediately
+      const placeholderId = `stream-${Date.now()}`
+      setMessages((prev) => [
+        ...prev,
+        {
+          role: 'assistant',
+          content: '',
+          message_id: placeholderId,
+          created_at: new Date().toISOString(),
+        },
+      ])
+
+      try {
+        while (true) {
+          const { done, value } = await reader.read()
+          if (done) break
+
+          buffer += decoder.decode(value, { stream: true })
+          const lines = buffer.split('\n')
+          buffer = lines.pop() || ''
+
+          for (const line of lines) {
+            if (!line.startsWith('data: ')) continue
+            try {
+              const event: StreamEvent = JSON.parse(line.slice(6))
+              switch (event.type) {
+                case 'status':
+                  setStatusMessage(event.message || null)
+                  break
+                case 'tool_start':
+                  setStatusMessage(event.message || `Running ${event.tool}...`)
+                  setActiveTools((prev) => [...prev, event.tool || ''])
+                  break
+                case 'tool_done':
+                  setActiveTools((prev) => prev.filter((t) => t !== event.tool))
+                  break
+                case 'text_delta':
+                  assistantText += event.text || ''
+                  setStatusMessage(null)
+                  setMessages((prev) =>
+                    prev.map((m) =>
+                      m.message_id === placeholderId
+                        ? { ...m, content: assistantText }
+                        : m,
+                    ),
+                  )
+                  break
+                case 'done':
+                  assistantId = event.message_id || ''
+                  newConversationId = event.conversation_id || ''
+                  break
+                case 'error':
+                  throw new Error(event.message || 'Chat error')
+              }
+            } catch (parseErr) {
+              if (parseErr instanceof Error && parseErr.message === 'Chat error') throw parseErr
+            }
+          }
+        }
+      } finally {
+        setIsLoading(false)
+        setStatusMessage(null)
+        setActiveTools([])
+        abortRef.current = null
+      }
+
+      // Update the placeholder with final ID
+      if (assistantId) {
+        setMessages((prev) =>
+          prev.map((m) =>
+            m.message_id === placeholderId
+              ? { ...m, message_id: assistantId, content: assistantText }
+              : m,
+          ),
+        )
+      }
+
+      if (newConversationId && !conversationId) {
+        setConversationId(newConversationId)
+      }
+
+      queryClient.invalidateQueries({ queryKey: ['conversations'] })
+    },
+    [conversationId, queryClient],
   )
 
   const startNewConversation = useCallback(() => {
     setConversationId(undefined)
     setMessages([])
     setIsRateLimited(false)
+    setError(null)
+    setStatusMessage(null)
+    setActiveTools([])
   }, [])
 
   const loadConversation = useCallback((id: string) => {
@@ -131,10 +261,12 @@ export function useChatSession(initialConversationId?: string) {
   return {
     conversationId,
     messages,
-    isLoading: sendMutation.isPending,
+    isLoading,
     isFetching: conversationQuery.isFetching,
     isRateLimited,
-    error: sendMutation.error,
+    statusMessage,
+    activeTools,
+    error,
     sendMessage,
     startNewConversation,
     loadConversation,

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -28,6 +28,8 @@ export function ChatPage() {
     messages,
     isLoading,
     isRateLimited,
+    statusMessage,
+    activeTools,
     sendMessage,
     startNewConversation,
     loadConversation,
@@ -179,7 +181,13 @@ export function ChatPage() {
         </div>
 
         {/* Messages */}
-        <ChatWindow messages={messages} isLoading={isLoading} />
+        <ChatWindow
+          messages={messages}
+          isLoading={isLoading}
+          statusMessage={statusMessage}
+          activeTools={activeTools}
+          onSuggestionClick={handleSend}
+        />
 
         {/* Rate limit + error banners */}
         {isRateLimited && (


### PR DESCRIPTION
## Summary
- **Streaming chat via Lambda Function URL**: SSE events for real-time updates (thinking, tool calls, text deltas) - ChatGPT-like experience
- **Tool tracing**: Each tool call logged with name, input, and duration in ms
- **Bedrock iteration timing**: Each Bedrock converse call timed and logged
- **maxTokens reverted to 2048** for better responses
- **Web client**: Streams text token-by-token, shows tool call indicators, status messages
- **Fallback**: Web client falls back to REST API if streaming URL not configured

## Architecture
- New `chat_stream_handler.py` - standalone Lambda handler for streaming
- Lambda Function URL with `RESPONSE_STREAM` invoke mode
- SSE event types: `status`, `tool_start`, `tool_done`, `text_delta`, `done`, `error`
- When auto-detect finds resort data, uses `converse_stream` without tools (fastest path)
- Otherwise runs tool loop with progress streaming

## Test plan
- [x] All 1366 backend tests pass
- [x] Web app builds cleanly (tsc + vite)
- [ ] Deploy and verify streaming works end-to-end
- [ ] Verify non-streaming REST fallback still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)