### PR TITLE
Add streaming chat with tool indicators to iOS

### DIFF
--- a/infrastructure/__main__.py
+++ b/infrastructure/__main__.py
@@ -1279,7 +1279,7 @@ chat_stream_url = aws.lambda_.FunctionUrl(
     invoke_mode="RESPONSE_STREAM",
     cors=aws.lambda_.FunctionUrlCorsArgs(
         allow_origins=["*"],
-        allow_methods=["POST", "OPTIONS"],
+        allow_methods=["*"],
         allow_headers=["Content-Type", "Authorization"],
         max_age=3600,
     ),

--- a/ios/SnowTracker.xcodeproj/project.pbxproj
+++ b/ios/SnowTracker.xcodeproj/project.pbxproj
@@ -40,6 +40,7 @@
 		74BA625B9E4FE88B4C6172C6 /* APIClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D7308D06F97AABEC540CD28 /* APIClient.swift */; };
 		75E9966D6DAC958DE49B8269 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 9DA3C8E41208AE034CEF3110 /* Assets.xcassets */; };
 		7AB63FA94855BFFC3BC3D96D /* CacheService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8480267002B460788F226295 /* CacheService.swift */; };
+		13466BC393B347DEA402AF27 /* ChatStreamService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D5A1C6F49264C58A2BBD5DA /* ChatStreamService.swift */; };
 		7B4D64BE9D189ECF26FE05D7 /* TimelineView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85F8A84962506DB38BA81FB7 /* TimelineView.swift */; };
 		83BFBF66519B19306415836C /* LiveActivityService.swift in Sources */ = {isa = PBXBuildFile; fileRef = B48EC86DA1144402981A655C /* LiveActivityService.swift */; };
 		846AE61CF19B698637C23B0B /* WidgetDataService.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCFAE2F42CB31F05913BA69F /* WidgetDataService.swift */; };
@@ -163,6 +164,7 @@
 		803860FB4C86259454D90307 /* nb */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = nb; path = nb.lproj/Localizable.strings; sourceTree = "<group>"; };
 		827594616C43CCF87E99B50E /* SnowTrackerWidgetBundle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SnowTrackerWidgetBundle.swift; sourceTree = "<group>"; };
 		8480267002B460788F226295 /* CacheService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CacheService.swift; sourceTree = "<group>"; };
+		3D5A1C6F49264C58A2BBD5DA /* ChatStreamService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatStreamService.swift; sourceTree = "<group>"; };
 		85F8A84962506DB38BA81FB7 /* TimelineView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimelineView.swift; sourceTree = "<group>"; };
 		89CDB4F02FB7AB5E6113AF9C /* SnowTrackerWidget.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = SnowTrackerWidget.entitlements; sourceTree = "<group>"; };
 		8BCC6D20537615D2F10A0472 /* SettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsView.swift; sourceTree = "<group>"; };
@@ -262,6 +264,7 @@
 				3D7308D06F97AABEC540CD28 /* APIClient.swift */,
 				D23B988BBFF873484906C493 /* AuthenticationService.swift */,
 				8480267002B460788F226295 /* CacheService.swift */,
+				3D5A1C6F49264C58A2BBD5DA /* ChatStreamService.swift */,
 				A882E15FD24B57516DE0B29E /* Configuration.swift */,
 				6C1BA087DD0B345FC02441ED /* DemoDataService.swift */,
 				B48EC86DA1144402981A655C /* LiveActivityService.swift */,
@@ -586,6 +589,7 @@
 				38D5CCC28385D7DC0208CB70 /* AuthenticationService.swift in Sources */,
 				24A3BDA567803E68B65547C7 /* AuthenticationViews.swift in Sources */,
 				7AB63FA94855BFFC3BC3D96D /* CacheService.swift in Sources */,
+				13466BC393B347DEA402AF27 /* ChatStreamService.swift in Sources */,
 				66FFDFC1CD8B83187747CF67 /* CardStyle.swift in Sources */,
 				13A14C16F7CFE989DFFE1964 /* ChatModels.swift in Sources */,
 				11D0DB5A4864269D0A8598E3 /* ChatView.swift in Sources */,

--- a/ios/SnowTracker/SnowTracker/Sources/Services/ChatStreamService.swift
+++ b/ios/SnowTracker/SnowTracker/Sources/Services/ChatStreamService.swift
@@ -1,0 +1,166 @@
+import Foundation
+import KeychainSwift
+import os.log
+
+private let streamLog = Logger(subsystem: "com.snowtracker.app", category: "ChatStream")
+
+/// SSE event types from the streaming chat Lambda
+enum ChatStreamEventType: String, Codable {
+    case status
+    case toolStart = "tool_start"
+    case toolDone = "tool_done"
+    case textDelta = "text_delta"
+    case done
+    case error
+}
+
+/// A single SSE event from the chat stream
+struct ChatStreamEvent: Codable {
+    let type: ChatStreamEventType
+    let message: String?
+    let tool: String?
+    let input: [String: AnyCodable]?
+    let durationMs: Int?
+    let text: String?
+    let conversationId: String?
+    let messageId: String?
+
+    enum CodingKeys: String, CodingKey {
+        case type, message, tool, input, text
+        case durationMs = "duration_ms"
+        case conversationId = "conversation_id"
+        case messageId = "message_id"
+    }
+}
+
+/// Callback-based interface for streaming chat events
+protocol ChatStreamDelegate: AnyObject {
+    @MainActor func chatStreamDidReceiveStatus(_ message: String)
+    @MainActor func chatStreamDidStartTool(_ tool: String, message: String?)
+    @MainActor func chatStreamDidFinishTool(_ tool: String)
+    @MainActor func chatStreamDidReceiveTextDelta(_ text: String)
+    @MainActor func chatStreamDidComplete(conversationId: String, messageId: String)
+    @MainActor func chatStreamDidFail(_ error: Error)
+}
+
+/// Service for consuming SSE chat streams from the Lambda Function URL
+final class ChatStreamService {
+    static let shared = ChatStreamService()
+    private init() {}
+
+    /// Whether streaming is available for the current environment
+    @MainActor
+    var isStreamingAvailable: Bool {
+        AppConfiguration.shared.selectedEnvironment.chatStreamURL != nil
+    }
+
+    /// Send a message via SSE streaming. Returns an async throwing stream of events.
+    func sendMessageStream(
+        message: String,
+        conversationId: String?
+    ) -> AsyncThrowingStream<ChatStreamEvent, Error> {
+        AsyncThrowingStream { continuation in
+            Task {
+                do {
+                    try await performStream(message: message, conversationId: conversationId, continuation: continuation)
+                } catch {
+                    continuation.finish(throwing: error)
+                }
+            }
+        }
+    }
+
+    private func performStream(
+        message: String,
+        conversationId: String?,
+        continuation: AsyncThrowingStream<ChatStreamEvent, Error>.Continuation
+    ) async throws {
+        let streamURL = await MainActor.run { AppConfiguration.shared.selectedEnvironment.chatStreamURL }
+        guard let url = streamURL else {
+            throw ChatStreamError.streamingNotAvailable
+        }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+
+        // Add auth token
+        let token = KeychainSwift().get("com.snowtracker.authToken")
+        if let token {
+            request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        }
+
+        // Build request body
+        var body: [String: Any] = ["message": message]
+        if let conversationId {
+            body["conversation_id"] = conversationId
+        }
+        request.httpBody = try JSONSerialization.data(withJSONObject: body)
+        request.timeoutInterval = 120
+
+        let (bytes, response) = try await URLSession.shared.bytes(for: request)
+
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw ChatStreamError.invalidResponse
+        }
+
+        guard httpResponse.statusCode == 200 else {
+            throw ChatStreamError.httpError(httpResponse.statusCode)
+        }
+
+        let decoder = JSONDecoder()
+        var buffer = ""
+
+        for try await byte in bytes {
+            let char = Character(UnicodeScalar(byte))
+            buffer.append(char)
+
+            // Process complete lines
+            while let newlineRange = buffer.range(of: "\n") {
+                let line = String(buffer[buffer.startIndex..<newlineRange.lowerBound])
+                buffer.removeSubrange(buffer.startIndex...newlineRange.lowerBound)
+
+                guard line.hasPrefix("data: ") else { continue }
+                let jsonString = String(line.dropFirst(6))
+                guard let jsonData = jsonString.data(using: .utf8) else { continue }
+
+                do {
+                    let event = try decoder.decode(ChatStreamEvent.self, from: jsonData)
+                    if event.type == .error {
+                        continuation.finish(throwing: ChatStreamError.serverError(event.message ?? "Unknown error"))
+                        return
+                    }
+                    continuation.yield(event)
+                    if event.type == .done {
+                        continuation.finish()
+                        return
+                    }
+                } catch {
+                    streamLog.warning("Failed to parse SSE event: \(jsonString)")
+                }
+            }
+        }
+
+        continuation.finish()
+    }
+}
+
+enum ChatStreamError: Error, LocalizedError {
+    case streamingNotAvailable
+    case invalidResponse
+    case httpError(Int)
+    case serverError(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .streamingNotAvailable:
+            return "Streaming is not available"
+        case .invalidResponse:
+            return "Invalid response from server"
+        case .httpError(let code):
+            return "Server error: \(code)"
+        case .serverError(let message):
+            return message
+        }
+    }
+}

--- a/ios/SnowTracker/SnowTracker/Sources/Services/Configuration.swift
+++ b/ios/SnowTracker/SnowTracker/Sources/Services/Configuration.swift
@@ -44,6 +44,19 @@ enum AppEnvironment: String, CaseIterable {
         }
     }
 
+    /// Chat streaming Lambda Function URL (SSE endpoint)
+    /// Returns nil if streaming is not yet deployed for this environment
+    var chatStreamURL: URL? {
+        switch self {
+        case .development:
+            return nil
+        case .staging:
+            return nil // Set after infrastructure deploy
+        case .production:
+            return nil // Set after infrastructure deploy
+        }
+    }
+
     var cognitoUserPoolId: String {
         switch self {
         case .development:

--- a/ios/SnowTracker/SnowTracker/Sources/ViewModels/ChatViewModel.swift
+++ b/ios/SnowTracker/SnowTracker/Sources/ViewModels/ChatViewModel.swift
@@ -16,15 +16,19 @@ final class ChatViewModel: ObservableObject {
 
     // MARK: - Streaming State
 
-    /// The message ID currently being streamed (progressive text reveal)
+    /// The message ID currently being streamed
     @Published var streamingMessageId: String?
     /// The text displayed so far during streaming
     @Published var displayedText: String = ""
+    /// Status message shown during tool execution (e.g. "Checking conditions...")
+    @Published var statusMessage: String?
+    /// Tools currently being executed
+    @Published var activeTools: [String] = []
 
-    /// Whether a message is currently being progressively revealed
+    /// Whether a message is currently being streamed
     var isStreaming: Bool { streamingMessageId != nil }
 
-    /// The full text of the message being streamed (used for skip)
+    /// The full text of the message being streamed (used for skip in non-SSE mode)
     private var fullStreamingText: String = ""
     /// The words of the full text, split for progressive reveal
     private var streamingWords: [String] = []
@@ -34,6 +38,7 @@ final class ChatViewModel: ObservableObject {
     private var streamingTask: Task<Void, Never>?
 
     private let apiClient = APIClient.shared
+    private let streamService = ChatStreamService.shared
 
     // MARK: - Send Message
 
@@ -43,6 +48,8 @@ final class ChatViewModel: ObservableObject {
 
         isSending = true
         errorMessage = nil
+        statusMessage = nil
+        activeTools = []
 
         // Add the user message optimistically
         let userMessage = ChatMessage(
@@ -53,11 +60,22 @@ final class ChatViewModel: ObservableObject {
         )
         messages.append(userMessage)
 
+        // Try SSE streaming first if available
+        if streamService.isStreamingAvailable {
+            do {
+                try await sendMessageViaStream(trimmed)
+                return
+            } catch {
+                chatLog.warning("Stream failed, falling back to REST: \(error)")
+                // Fall through to REST
+            }
+        }
+
+        // Fallback: non-streaming REST call
         do {
             let response = try await sendWithAutoRefresh(trimmed)
             currentConversationId = response.conversationId
 
-            // Add assistant response with empty content initially
             let assistantMessage = ChatMessage(
                 id: response.messageId,
                 role: .assistant,
@@ -67,8 +85,8 @@ final class ChatViewModel: ObservableObject {
             messages.append(assistantMessage)
             isSending = false
 
-            // Start progressive text reveal
-            await startStreaming(messageId: response.messageId, fullText: response.response)
+            // Start progressive text reveal for REST responses
+            await startLocalStreaming(messageId: response.messageId, fullText: response.response)
             chatLog.debug("Chat response received for conversation \(response.conversationId)")
         } catch APIError.unauthorized {
             chatLog.error("Chat unauthorized after refresh attempt")
@@ -93,6 +111,102 @@ final class ChatViewModel: ObservableObject {
             messages.append(errorResponse)
             isSending = false
         }
+    }
+
+    // MARK: - SSE Streaming
+
+    private func sendMessageViaStream(_ text: String) async throws {
+        let placeholderId = "stream-\(UUID().uuidString)"
+
+        // Add placeholder assistant message
+        let placeholder = ChatMessage(
+            id: placeholderId,
+            role: .assistant,
+            content: "",
+            createdAt: Date()
+        )
+        messages.append(placeholder)
+
+        var assistantText = ""
+        var finalMessageId = ""
+        var finalConversationId = ""
+
+        let stream = streamService.sendMessageStream(
+            message: text,
+            conversationId: currentConversationId
+        )
+
+        do {
+            for try await event in stream {
+                switch event.type {
+                case .status:
+                    statusMessage = event.message
+                case .toolStart:
+                    statusMessage = event.message ?? "Running \(event.tool ?? "tool")..."
+                    if let tool = event.tool {
+                        activeTools.append(tool)
+                    }
+                case .toolDone:
+                    if let tool = event.tool {
+                        activeTools.removeAll { $0 == tool }
+                    }
+                case .textDelta:
+                    assistantText += event.text ?? ""
+                    statusMessage = nil
+                    // Update placeholder content
+                    if let index = messages.firstIndex(where: { $0.id == placeholderId }) {
+                        messages[index] = ChatMessage(
+                            id: placeholderId,
+                            role: .assistant,
+                            content: assistantText,
+                            createdAt: Date()
+                        )
+                    }
+                    displayedText = assistantText
+                    streamingMessageId = placeholderId
+                case .done:
+                    finalMessageId = event.messageId ?? ""
+                    finalConversationId = event.conversationId ?? ""
+                case .error:
+                    throw ChatStreamError.serverError(event.message ?? "Chat error")
+                }
+            }
+        } catch {
+            // Clean up on error
+            isSending = false
+            statusMessage = nil
+            activeTools = []
+            streamingMessageId = nil
+            displayedText = ""
+            // Remove placeholder if no text was received
+            if assistantText.isEmpty {
+                messages.removeAll { $0.id == placeholderId }
+            }
+            throw error
+        }
+
+        // Update placeholder with final ID
+        if !finalMessageId.isEmpty {
+            if let index = messages.firstIndex(where: { $0.id == placeholderId }) {
+                messages[index] = ChatMessage(
+                    id: finalMessageId,
+                    role: .assistant,
+                    content: assistantText,
+                    createdAt: Date()
+                )
+            }
+        }
+
+        if !finalConversationId.isEmpty, currentConversationId == nil {
+            currentConversationId = finalConversationId
+        }
+
+        isSending = false
+        statusMessage = nil
+        activeTools = []
+        streamingMessageId = nil
+        displayedText = ""
+        chatLog.debug("Stream complete for conversation \(finalConversationId)")
     }
 
     // MARK: - Auto Token Refresh
@@ -120,10 +234,10 @@ final class ChatViewModel: ObservableObject {
         }
     }
 
-    // MARK: - Streaming
+    // MARK: - Local Streaming (Progressive Text Reveal for REST)
 
     /// Start progressive text reveal for a message (~30 words/second)
-    private func startStreaming(messageId: String, fullText: String) async {
+    private func startLocalStreaming(messageId: String, fullText: String) async {
         fullStreamingText = fullText
         streamingWords = fullText.splitKeepingSeparators()
         streamingWordIndex = 0

--- a/ios/SnowTracker/SnowTracker/Sources/Views/ChatView.swift
+++ b/ios/SnowTracker/SnowTracker/Sources/Views/ChatView.swift
@@ -117,8 +117,16 @@ struct ChatView: View {
                     }
 
                     if viewModel.isSending {
-                        TypingIndicatorView()
-                            .id("typing-indicator")
+                        if viewModel.statusMessage != nil || !viewModel.activeTools.isEmpty {
+                            ToolStatusView(
+                                statusMessage: viewModel.statusMessage,
+                                activeTools: viewModel.activeTools
+                            )
+                            .id("tool-status")
+                        } else if !viewModel.isStreaming {
+                            TypingIndicatorView()
+                                .id("typing-indicator")
+                        }
                     }
 
                     if let error = viewModel.errorMessage {
@@ -148,6 +156,12 @@ struct ChatView: View {
                         proxy.scrollTo(messageId, anchor: .bottom)
                     }
                 }
+            }
+            .onChange(of: viewModel.statusMessage) { _, _ in
+                scrollToBottom(proxy: proxy)
+            }
+            .onChange(of: viewModel.activeTools.count) { _, _ in
+                scrollToBottom(proxy: proxy)
             }
         }
     }
@@ -218,7 +232,11 @@ struct ChatView: View {
     private func scrollToBottom(proxy: ScrollViewProxy) {
         withAnimation(.easeOut(duration: 0.3)) {
             if viewModel.isSending {
-                proxy.scrollTo("typing-indicator", anchor: .bottom)
+                if viewModel.statusMessage != nil || !viewModel.activeTools.isEmpty {
+                    proxy.scrollTo("tool-status", anchor: .bottom)
+                } else {
+                    proxy.scrollTo("typing-indicator", anchor: .bottom)
+                }
             } else if let lastMessage = viewModel.messages.last {
                 proxy.scrollTo(lastMessage.id, anchor: .bottom)
             }
@@ -281,6 +299,54 @@ private struct MessageBubbleView: View {
                 Spacer(minLength: 60)
             }
         }
+    }
+}
+
+// MARK: - Tool Status View
+
+private struct ToolStatusView: View {
+    let statusMessage: String?
+    let activeTools: [String]
+
+    var body: some View {
+        HStack {
+            VStack(alignment: .leading, spacing: 6) {
+                if let status = statusMessage {
+                    HStack(spacing: 8) {
+                        ProgressView()
+                            .controlSize(.small)
+                        Text(status)
+                            .font(.subheadline)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+
+                if !activeTools.isEmpty {
+                    HStack(spacing: 6) {
+                        ForEach(activeTools, id: \.self) { tool in
+                            HStack(spacing: 4) {
+                                Image(systemName: "wrench.and.screwdriver")
+                                    .font(.caption2)
+                                Text(tool)
+                                    .font(.caption)
+                            }
+                            .padding(.horizontal, 8)
+                            .padding(.vertical, 4)
+                            .background(Color.blue.opacity(0.1))
+                            .foregroundStyle(.blue)
+                            .clipShape(Capsule())
+                        }
+                    }
+                }
+            }
+            .padding(.horizontal, 14)
+            .padding(.vertical, 10)
+            .background(Color(.secondarySystemBackground))
+            .clipShape(RoundedRectangle(cornerRadius: 18))
+
+            Spacer(minLength: 60)
+        }
+        .accessibilityLabel(statusMessage ?? "Processing")
     }
 }
 


### PR DESCRIPTION
## Summary
- Add `ChatStreamService` for consuming SSE events from the chat streaming Lambda Function URL
- Update `ChatViewModel` to try SSE streaming, falling back to REST API
- Show real-time status messages during tool execution (e.g. "Checking conditions at Whistler...")
- Display tool badges for active tool calls
- Add `chatStreamURL` to `AppEnvironment` (URLs set after infrastructure deploy)
- Fix Lambda Function URL CORS: `OPTIONS` exceeds 6-char method limit, use `*` wildcard

## Test plan
- [ ] Chat still works via REST fallback (streaming URLs not yet configured)
- [ ] Tool status indicators appear when SSE streaming is connected
- [ ] Progressive text reveal works for REST fallback
- [ ] Build succeeds with no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)