### PR TITLE
Stop revoking Apple certs on every build

### DIFF
--- a/.github/workflows/ios-build.yml
+++ b/.github/workflows/ios-build.yml
@@ -1,9 +1,9 @@
 name: iOS Build
 
 # Inline build workflow using App Store Connect API for automatic signing.
-# A cert cleanup step runs before each archive to revoke excess development
-# certificates (Xcode creates a new one per ephemeral CI build). This keeps
-# the certificate count under Apple's limit automatically.
+# A stored .p12 signing certificate is imported from GitHub Secrets into a
+# temporary keychain. This prevents Xcode from creating a new certificate
+# on every build (ephemeral runners have no persistent keychain).
 
 on:
   push:
@@ -106,75 +106,39 @@ jobs:
         echo "${{ secrets.APP_STORE_CONNECT_PRIVATE_KEY }}" | tr -d '\r' > $RUNNER_TEMP/private_keys/AuthKey_${{ secrets.APP_STORE_CONNECT_KEY_ID }}.p8
         chmod 600 $RUNNER_TEMP/private_keys/AuthKey_${{ secrets.APP_STORE_CONNECT_KEY_ID }}.p8
 
-    - name: Cleanup excess certificates
-      if: github.event_name != 'pull_request'
+    - name: Import signing certificate
+      if: github.event_name != 'pull_request' && env.CERT_P12_BASE64 != ''
+      env:
+        CERT_P12_BASE64: ${{ secrets.APPLE_CERT_P12_BASE64 }}
+        CERT_P12_PASSWORD: ${{ secrets.APPLE_CERT_P12_PASSWORD }}
       run: |
-        # Revoke excess development certificates to prevent hitting Apple's limit.
-        # Xcode automatic signing creates a new dev cert on each CI build because
-        # ephemeral runners have no certs in their keychain. This step keeps only
-        # the newest dev cert and removes the rest via the ASC API.
-        python3 - "${{ secrets.APP_STORE_CONNECT_KEY_ID }}" "${{ secrets.APP_STORE_CONNECT_ISSUER_ID }}" "$RUNNER_TEMP/private_keys/AuthKey_${{ secrets.APP_STORE_CONNECT_KEY_ID }}.p8" << 'PYTHON_SCRIPT'
-        import sys, json, time, base64, struct, urllib.request, urllib.error
-        from cryptography.hazmat.primitives import hashes, serialization
-        from cryptography.hazmat.primitives.asymmetric import ec, utils
+        # Import a stored signing certificate so Xcode reuses it
+        # instead of creating (and later revoking) a new one each build.
+        KEYCHAIN_PATH=$RUNNER_TEMP/signing.keychain-db
+        KEYCHAIN_PASSWORD="$(openssl rand -hex 16)"
 
-        key_id, issuer_id, key_path = sys.argv[1], sys.argv[2], sys.argv[3]
+        # Create a temporary keychain
+        security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+        security set-keychain-settings -lut 21600 "$KEYCHAIN_PATH"
+        security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
 
-        def b64url(data):
-            return base64.urlsafe_b64encode(data).rstrip(b'=').decode()
+        # Import the .p12 certificate
+        echo "$CERT_P12_BASE64" | base64 --decode > $RUNNER_TEMP/cert.p12
+        security import $RUNNER_TEMP/cert.p12 \
+          -P "$CERT_P12_PASSWORD" \
+          -A -t cert -f pkcs12 \
+          -k "$KEYCHAIN_PATH"
 
-        # Generate ASC API JWT
-        with open(key_path, 'rb') as f:
-            private_key = serialization.load_pem_private_key(f.read(), password=None)
-        header = b64url(json.dumps({"alg": "ES256", "kid": key_id, "typ": "JWT"}).encode())
-        now = int(time.time())
-        payload = b64url(json.dumps({"iss": issuer_id, "iat": now, "exp": now + 600, "aud": "appstoreconnect-v1"}).encode())
-        signing_input = f"{header}.{payload}".encode()
-        der_sig = private_key.sign(signing_input, ec.ECDSA(hashes.SHA256()))
-        r, s = utils.decode_dss_signature(der_sig)
-        sig = r.to_bytes(32, 'big') + s.to_bytes(32, 'big')
-        token = f"{header}.{payload}.{b64url(sig)}"
+        # Allow codesign to access the keychain without prompts
+        security set-key-partition-list -S apple-tool:,apple:,codesign: \
+          -s -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
 
-        headers = {"Authorization": f"Bearer {token}"}
+        # Add to keychain search list (prepend so our keychain is checked first)
+        security list-keychains -d user -s "$KEYCHAIN_PATH" $(security list-keychains -d user | tr -d '"')
 
-        def api_get(url):
-            req = urllib.request.Request(url, headers=headers)
-            return json.loads(urllib.request.urlopen(req).read())
-
-        def api_delete(url):
-            req = urllib.request.Request(url, headers=headers, method='DELETE')
-            try:
-                urllib.request.urlopen(req)
-                return True
-            except urllib.error.HTTPError:
-                return False
-
-        # List all certificates
-        data = api_get("https://api.appstoreconnect.apple.com/v1/certificates?limit=200")
-        certs = data.get("data", [])
-
-        # Separate by type: keep 1 dev cert, keep 2 distribution certs
-        dev_certs = [c for c in certs if "DEVELOPMENT" in c["attributes"]["certificateType"]]
-        dist_certs = [c for c in certs if "DISTRIBUTION" in c["attributes"]["certificateType"]]
-
-        dev_certs.sort(key=lambda c: c["attributes"].get("expirationDate", ""), reverse=True)
-        dist_certs.sort(key=lambda c: c["attributes"].get("expirationDate", ""), reverse=True)
-
-        revoked = 0
-        for cert in dev_certs[1:]:  # Keep newest 1
-            name = cert["attributes"].get("name", cert["id"])
-            if api_delete(f"https://api.appstoreconnect.apple.com/v1/certificates/{cert['id']}"):
-                print(f"Revoked dev cert: {name}")
-                revoked += 1
-
-        for cert in dist_certs[2:]:  # Keep newest 2
-            name = cert["attributes"].get("name", cert["id"])
-            if api_delete(f"https://api.appstoreconnect.apple.com/v1/certificates/{cert['id']}"):
-                print(f"Revoked dist cert: {name}")
-                revoked += 1
-
-        print(f"Certificate cleanup: {len(dev_certs)} dev, {len(dist_certs)} dist found; {revoked} revoked")
-        PYTHON_SCRIPT
+        echo "SIGNING_KEYCHAIN_PATH=$KEYCHAIN_PATH" >> $GITHUB_ENV
+        echo "Signing certificate imported into temporary keychain"
+        rm -f $RUNNER_TEMP/cert.p12
 
     - name: Build (PR - no signing)
       if: github.event_name == 'pull_request'
@@ -263,4 +227,7 @@ jobs:
     - name: Cleanup
       if: always()
       run: |
+        if [ -n "$SIGNING_KEYCHAIN_PATH" ] && [ -f "$SIGNING_KEYCHAIN_PATH" ]; then
+          security delete-keychain "$SIGNING_KEYCHAIN_PATH" 2>/dev/null || true
+        fi
         rm -rf $RUNNER_TEMP/private_keys $RUNNER_TEMP/Export


### PR DESCRIPTION
## Summary
- Replace the cert cleanup/revocation step with a stored certificate import
- Import a .p12 signing certificate from GitHub Secrets into a temporary keychain
- Xcode finds the cert in the keychain and reuses it (no new cert created)
- No more Apple email notifications for revoked certificates
- Falls back gracefully if `APPLE_CERT_P12_BASE64` secret is not yet set

## Setup required
Export your Apple Development + Distribution certificates as `.p12`:
1. Open Keychain Access
2. Find "Apple Development: wouter.devriendt@gmail.com" cert
3. Right-click → Export → save as `.p12` with password
4. Base64-encode: `base64 -i cert.p12 | pbcopy`
5. Add GitHub Secrets:
   - `APPLE_CERT_P12_BASE64` = base64 string
   - `APPLE_CERT_P12_PASSWORD` = password you chose

## Test plan
- [ ] Without secrets set: build still works (Xcode creates cert as before)
- [ ] With secrets set: no new cert created, no revocation emails

🤖 Generated with [Claude Code](https://claude.com/claude-code)