### PR TITLE
Configure chat streaming URLs for iOS and web

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -456,7 +456,9 @@ jobs:
 
         # Install dependencies and build
         npm ci
-        VITE_API_URL=https://api.powderchaserapp.com npm run build
+        VITE_API_URL=https://api.powderchaserapp.com \
+        VITE_CHAT_STREAM_URL=https://z3s2kwjc2cs6zhhgui3jmus5e40igoyr.lambda-url.us-west-2.on.aws/ \
+        npm run build
 
         # Get bucket name and CloudFront distribution ID from Pulumi
         cd ../infrastructure

--- a/ios/SnowTracker/SnowTracker/Sources/Services/Configuration.swift
+++ b/ios/SnowTracker/SnowTracker/Sources/Services/Configuration.swift
@@ -45,15 +45,14 @@ enum AppEnvironment: String, CaseIterable {
     }
 
     /// Chat streaming Lambda Function URL (SSE endpoint)
-    /// Returns nil if streaming is not yet deployed for this environment
     var chatStreamURL: URL? {
         switch self {
         case .development:
             return nil
         case .staging:
-            return nil // Set after infrastructure deploy
+            return URL(string: "https://h5yv2vpzlchdpbvnf2ddc6v5xu0lmztp.lambda-url.us-west-2.on.aws/")
         case .production:
-            return nil // Set after infrastructure deploy
+            return URL(string: "https://z3s2kwjc2cs6zhhgui3jmus5e40igoyr.lambda-url.us-west-2.on.aws/")
         }
     }
 


### PR DESCRIPTION
## Summary
- Set Lambda Function URLs for chat streaming in iOS `AppEnvironment` (staging + prod)
- Pass `VITE_CHAT_STREAM_URL` to web app build in deploy workflow
- Enables real SSE streaming with tool indicators for both platforms

## Test plan
- [ ] iOS chat shows tool status indicators when streaming is connected
- [ ] Web app uses SSE streaming after next prod deploy
- [ ] Fallback to REST still works if stream connection fails

🤖 Generated with [Claude Code](https://claude.com/claude-code)