### PR TITLE
Fix Lambda Function URL 403 by adding explicit permission

### DIFF
--- a/infrastructure/__main__.py
+++ b/infrastructure/__main__.py
@@ -1288,6 +1288,15 @@ chat_stream_url = aws.lambda_.FunctionUrl(
 pulumi.export("chat_stream_url", chat_stream_url.function_url)
 pulumi.export("chat_stream_lambda_name", chat_stream_lambda.name)
 
+# Permission for public access to chat stream Function URL
+chat_stream_permission = aws.lambda_.Permission(
+    f"{app_name}-chat-stream-url-permission-{environment}",
+    action="lambda:InvokeFunctionUrl",
+    function=chat_stream_lambda.name,
+    principal="*",
+    function_url_auth_type="NONE",
+)
+
 # Permission for API Gateway to invoke the API handler Lambda
 api_handler_permission = aws.lambda_.Permission(
     f"{app_name}-api-handler-permission-{environment}",


### PR DESCRIPTION
## Summary
- Add explicit `aws.lambda_.Permission` resource for the chat streaming Lambda Function URL
- Without this, the Function URL returns 403 Forbidden (`AccessDeniedException`) even though `authorization_type` is `NONE`
- The resource-based policy created by `FunctionUrl` alone is not sufficient — an explicit permission granting `lambda:InvokeFunctionUrl` to principal `*` is required

## Test plan
- [ ] Deploy to staging and verify `curl -X POST` to the Function URL no longer returns 403
- [ ] Test SSE streaming from iOS app and web app

🤖 Generated with [Claude Code](https://claude.com/claude-code)