### PR TITLE
Fix Lambda Function URL 403: add InvokeFunction permission

### DIFF
--- a/infrastructure/__main__.py
+++ b/infrastructure/__main__.py
@@ -1288,13 +1288,21 @@ chat_stream_url = aws.lambda_.FunctionUrl(
 pulumi.export("chat_stream_url", chat_stream_url.function_url)
 pulumi.export("chat_stream_lambda_name", chat_stream_lambda.name)
 
-# Permission for public access to chat stream Function URL
-chat_stream_permission = aws.lambda_.Permission(
+# Permissions for public access to chat stream Function URL
+# Since Oct 2025, AWS requires both InvokeFunctionUrl AND InvokeFunction
+chat_stream_url_permission = aws.lambda_.Permission(
     f"{app_name}-chat-stream-url-permission-{environment}",
     action="lambda:InvokeFunctionUrl",
     function=chat_stream_lambda.name,
     principal="*",
     function_url_auth_type="NONE",
+)
+
+chat_stream_invoke_permission = aws.lambda_.Permission(
+    f"{app_name}-chat-stream-invoke-permission-{environment}",
+    action="lambda:InvokeFunction",
+    function=chat_stream_lambda.name,
+    principal="*",
 )
 
 # Permission for API Gateway to invoke the API handler Lambda


### PR DESCRIPTION
## Summary
- Since October 2025, AWS requires **both** `lambda:InvokeFunctionUrl` AND `lambda:InvokeFunction` permissions for public Lambda Function URLs
- Without `InvokeFunction`, the URL returns 403 Forbidden (`AccessDeniedException`) even with `AuthType: NONE` and correct `InvokeFunctionUrl` policy
- Tested manually: adding `InvokeFunction` permission immediately resolves the 403

## Test plan
- [x] Verified fix manually on staging via `aws lambda add-permission` + curl
- [ ] Deploy to staging via Pulumi and verify curl returns 200
- [ ] Deploy to prod and verify streaming works end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)