### PR TITLE
Add AWS_LAMBDA_EXEC_WRAPPER for Lambda Web Adapter

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -235,7 +235,7 @@ jobs:
           aws lambda wait function-updated --function-name "$CHAT_STREAM_LAMBDA" --region us-west-2
           aws lambda update-function-configuration \
             --function-name "$CHAT_STREAM_LAMBDA" \
-            --environment "Variables={ENVIRONMENT=${{ env.ENVIRONMENT }},CHAT_TABLE_NAME=snow-tracker-chat-${{ env.ENVIRONMENT }},RESULTS_BUCKET=snow-tracker-pulumi-state-us-west-2,AWS_REGION_NAME=us-west-2,AWS_LWA_INVOKE_MODE=response_stream,AWS_LWA_PORT=8080,AWS_LWA_READINESS_CHECK_PATH=/,PYTHONPATH=/var/task}" \
+            --environment "Variables={ENVIRONMENT=${{ env.ENVIRONMENT }},CHAT_TABLE_NAME=snow-tracker-chat-${{ env.ENVIRONMENT }},RESULTS_BUCKET=snow-tracker-pulumi-state-us-west-2,AWS_REGION_NAME=us-west-2,AWS_LAMBDA_EXEC_WRAPPER=/opt/bootstrap,AWS_LWA_INVOKE_MODE=response_stream,AWS_LWA_PORT=8080,AWS_LWA_READINESS_CHECK_PATH=/,PYTHONPATH=/var/task}" \
             --handler run.sh \
             --layers "arn:aws:lambda:us-west-2:753240598075:layer:LambdaAdapterLayerX86:26" \
             --region us-west-2

--- a/infrastructure/__main__.py
+++ b/infrastructure/__main__.py
@@ -1273,6 +1273,7 @@ chat_stream_lambda = aws.lambda_.Function(
             "CHAT_TABLE_NAME": f"{app_name}-chat-{environment}",
             "RESULTS_BUCKET": "snow-tracker-pulumi-state-us-west-2",
             "AWS_REGION_NAME": aws_region,
+            "AWS_LAMBDA_EXEC_WRAPPER": "/opt/bootstrap",
             "AWS_LWA_INVOKE_MODE": "response_stream",
             "AWS_LWA_PORT": "8080",
             "AWS_LWA_READINESS_CHECK_PATH": "/",


### PR DESCRIPTION
## Summary
- The LWA layer needs `AWS_LAMBDA_EXEC_WRAPPER=/opt/bootstrap` to intercept the Lambda runtime
- Without this, Lambda tries to import `run.sh` as a Python module (`No module named 'run'`)
- The exec wrapper tells Lambda to use the LWA bootstrap which runs `run.sh` as a shell script

## Test plan
- [ ] Deploy to staging and verify SSE streaming starts correctly
- [ ] curl returns SSE events instead of import error

🤖 Generated with [Claude Code](https://claude.com/claude-code)