### PR TITLE
Fix snow history empty + debug notifications on TestFlight

### DIFF
--- a/DIARY.md
+++ b/DIARY.md
@@ -7,6 +7,36 @@ Status: done | pending | n/a (not applicable) | backlog
 
 ## Feb 26, 2026
 
+### Fix: Table column alignment in AI chat markdown renderer
+Tables with alternating row colors had misaligned columns because each row's HStack was laid out independently in a VStack. Fixed by: (1) computing an explicit `totalWidth` from column widths + separator widths, (2) applying `.frame(width: totalWidth)` to every row HStack and the container VStack, (3) extracting a shared `tableRow()` builder so header and data rows use identical layout code, (4) adding explicit widths to inter-row separator lines. All columns now align perfectly across all rows.
+| iOS | Android | Web | API |
+|-----|---------|-----|-----|
+| done | pending | n/a | n/a |
+
+### Fix: Chat history not loading end-to-end in iOS app
+Backend was fixed (Float->Decimal), but iOS app had multiple UX issues preventing history from working properly: (1) ConversationListView swallowed errors silently — if loading failed, user just saw "No Conversations" with no retry option. Added dedicated `isLoadingConversations` and `conversationListError` states with error display and retry button. (2) Tapping a conversation dismissed the sheet immediately before the load completed, so messages appeared with no feedback. Now waits for the API call to finish (with per-row spinner) before dismissing. (3) Main chat view showed empty suggestions when `isLoading` was true during conversation load. Now shows a centered "Loading conversation..." spinner. (4) Added cleanup of streaming state before loading historical conversations to prevent stale data.
+| iOS | Android | Web | API |
+|-----|---------|-----|-----|
+| done | n/a | n/a | n/a |
+
+### Verified: 16 diverse chat suggestions already in place
+Confirmed 16 ChatSuggestion entries covering: proximity-based, budget, resort comparisons, regional (Rockies/Alps/Japan), family-friendly, pass-based (Ikon/Epic), forecasts, hidden gems, snowpack, and temperature queries. No changes needed.
+| iOS | Android | Web | API |
+|-----|---------|-----|-----|
+| done | pending | n/a | n/a |
+
+### Fix: Snow history empty — DAILY_HISTORY_TABLE env var missing from Lambda functions
+Root cause (again): `DAILY_HISTORY_TABLE` env var was not present on the weather worker, weather processor, or API handler Lambda functions in prod and staging. Despite being defined in Pulumi infrastructure code, the infra was never deployed after adding it. Weather worker defaulted to `snow-tracker-daily-history-dev` (which doesn't exist), so all history writes silently failed. Also missing: `SNOW_SUMMARY_TABLE` on API handler, `SNOW_SUMMARY_TABLE` on weather processor Pulumi config. Fixed: set env vars on all 6 Lambda functions (3 prod + 3 staging) via AWS CLI, updated Pulumi infra to include `SNOW_SUMMARY_TABLE` for weather processor, weather worker, and API handler. Triggered weather processor to backfill data. Table went from 122 to 1066+ records.
+| iOS | Android | Web | API |
+|-----|---------|-----|-----|
+| n/a | n/a | n/a | done |
+
+### Fix: Debug notification testing returns "debug features not available" on TestFlight
+Debug endpoints (`/api/v1/debug/test-push-notification` and `/api/v1/debug/trigger-notifications`) blocked ALL production requests with HTTP 403. TestFlight builds use the production API (not staging), so admin users testing via TestFlight always got blocked. Fix: added admin user identification via SHA256 email hash check (same hash list as iOS `Configuration.swift`). Admin users can now access debug endpoints in production. Also fixed test notification using `APNS_SANDBOX` in prod (should be `APNS` for production push certificates). Added 7 new tests for debug endpoint access control. Total: 1563 backend tests passing.
+| iOS | Android | Web | API |
+|-----|---------|-----|-----|
+| n/a | n/a | n/a | done |
+
 ### Feature: Data sources moved to bottom, shows excluded sources with reasons
 Data sources card moved from inline (between conditions cards) to the very bottom of resort detail view. Backend now includes all 4 known sources (Open-Meteo, OnTheSnow, Snow-Forecast, WeatherKit) in `source_details` even when a source has no data for the resort (status: `no_data`). Sources sorted by status: consensus first, then included, outlier, unavailable. Excluded outlier values shown with strikethrough and orange reason text. Unavailable sources shown as greyed "N/A".
 | iOS | Android | Web | API |

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -21,13 +21,13 @@
 4. [ ] **Chat history still doesn't work** — Is it linked to the logged-in user? Do I need to logout/login? Repro this and iterate until it works end-to-end in the app.
 5. [ ] **Add city to resort titles** — Show "Big White, Kelowna, BC, Canada" style titles. Add city field to all resorts; fetch/collect this data if needed via agents.
 6. [ ] **Resort logo in detail view** — If available, show a logo for the resort in the top cell of the detail view.
-7. [ ] **Snow history still empty** — e.g., Big White snowed yesterday and the feature has existed for 5+ days. Diagnose and fix.
+7. [x] **Snow history still empty** — Fixed: DAILY_HISTORY_TABLE env var missing from weather worker, weather processor, and API handler Lambdas (prod + staging). Also added SNOW_SUMMARY_TABLE to API handler. Fixed Pulumi infra to persist these env vars.
 8. [ ] **Website opens in new tab** — Open powderchaserapp.com in an embedded browser overlay, not a new Safari tab.
 9. [ ] **Webcam pages / main webcam on detail view** — Collect webcam page URLs for all resorts; if possible, show the main webcam image on the resort detail front page.
 10. [ ] **Map: default to hybrid, remember selection, forecast refresh on zoom** — Standard map should default to hybrid style. Remember user's map style selection in UserDefaults. In forecast mode, trigger refresh of new resorts in view on zoom release (not only on date selector change).
 11. [ ] **Clarify or remove pin icon** — There's a pin icon next to the heart (favorite) icon. Heart = favorite, but what is pin? Clarify its purpose or remove it.
 12. [ ] **Re-launch onboarding from settings** — Allow user to restart the onboarding tutorial from settings. Also review onboarding pages and update if needed.
-13. [ ] **Push notifications don't work** — Test notifications as a dev (debug staging via login email). The test section is always present but doesn't work via TestFlight: "debug features not available in this environment." Fix this.
+13. [x] **Push notifications don't work** — Fixed: Debug endpoints blocked all prod requests (TestFlight uses prod API). Added admin user check via email hash so admin users can use debug endpoints in prod. Also fixed APNS_SANDBOX→APNS for prod notifications.
 14. [ ] **App still called "Snow Tracker" in places** — All references should be "Powder Chaser." Find and fix all remaining "Snow Tracker" references.
 
 ### TODO: Cross-platform (Web + Android)

--- a/backend/src/handlers/api_handler.py
+++ b/backend/src/handlers/api_handler.py
@@ -2932,8 +2932,42 @@ async def delete_condition_report(
 
 
 # =============================================================================
-# MARK: - Test/Debug Endpoints (for development only)
+# MARK: - Test/Debug Endpoints (for development and admin users)
 # =============================================================================
+
+# SHA256 hashes of admin email addresses (same as iOS Configuration.swift)
+ADMIN_EMAIL_HASHES = {
+    "6e5c948b6cd14e94776b2abf9d324aa3a6606a3411bf7aefc36d0e74fd15faa0"
+}
+
+
+def _is_admin_user(user_id: str | None) -> bool:
+    """Check if the user is an admin based on their email hash."""
+    if not user_id:
+        return False
+    try:
+        import hashlib
+
+        user_service = get_user_service()
+        user = user_service.get_user(user_id)
+        if user and user.email:
+            email_hash = hashlib.sha256(user.email.lower().encode("utf-8")).hexdigest()
+            return email_hash in ADMIN_EMAIL_HASHES
+    except Exception as e:
+        logger.warning("Failed to check admin status for user %s: %s", user_id, e)
+    return False
+
+
+def _check_debug_access(environment: str, user_id: str | None):
+    """Check if debug endpoints are accessible. Allows staging/dev or admin users in prod."""
+    if environment != "prod":
+        return  # Always allowed in non-prod
+    if _is_admin_user(user_id):
+        return  # Admin users can access debug endpoints in prod
+    raise HTTPException(
+        status_code=status.HTTP_403_FORBIDDEN,
+        detail="This endpoint is not available in production",
+    )
 
 
 @app.post("/api/v1/debug/trigger-notifications")
@@ -2943,18 +2977,13 @@ async def trigger_notifications(
     """
     Manually trigger the notification processor for testing.
     This invokes the notification Lambda asynchronously.
-    Only available in staging environment. Auth is optional.
+    Available in staging/dev, or for admin users in production.
     """
     import boto3
 
     environment = os.environ.get("ENVIRONMENT", "dev")
 
-    # Only allow in staging for testing
-    if environment == "prod":
-        raise HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN,
-            detail="This endpoint is not available in production",
-        )
+    _check_debug_access(environment, user_id)
 
     try:
         lambda_client = boto3.client(
@@ -3001,18 +3030,13 @@ async def test_push_notification(
     """
     Send a test push notification to devices.
     If authenticated, sends to user's devices. Otherwise, sends to all devices.
-    Only available in staging environment. Auth is optional.
+    Available in staging/dev, or for admin users in production.
     """
     import boto3
 
     environment = os.environ.get("ENVIRONMENT", "dev")
 
-    # Only allow in staging for testing
-    if environment == "prod":
-        raise HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN,
-            detail="This endpoint is not available in production",
-        )
+    _check_debug_access(environment, user_id)
 
     try:
         # Get device tokens
@@ -3081,9 +3105,11 @@ async def test_push_notification(
                     "test": True,
                 }
 
+                # Use APNS for prod, APNS_SANDBOX for staging/dev
+                apns_key = "APNS" if environment == "prod" else "APNS_SANDBOX"
                 sns_client.publish(
                     TargetArn=endpoint_arn,
-                    Message=json.dumps({"APNS_SANDBOX": json.dumps(apns_payload)}),
+                    Message=json.dumps({apns_key: json.dumps(apns_payload)}),
                     MessageStructure="json",
                 )
 

--- a/backend/tests/test_api_handler.py
+++ b/backend/tests/test_api_handler.py
@@ -1721,3 +1721,71 @@ class TestErrorHandlers:
         schema = resp.json()
         assert "openapi" in schema
         assert "paths" in schema
+
+
+class TestDebugEndpoints:
+    """Test debug/admin endpoint access control."""
+
+    def test_debug_trigger_blocked_in_prod_for_non_admin(self, client):
+        """Debug trigger-notifications should return 403 in prod for non-admin users."""
+        with patch.dict("os.environ", {"ENVIRONMENT": "prod"}):
+            resp = client.post("/api/v1/debug/trigger-notifications")
+            assert resp.status_code == 403
+
+    def test_debug_test_push_blocked_in_prod_for_non_admin(self, client):
+        """Debug test-push-notification should return 403 in prod for non-admin users."""
+        with patch.dict("os.environ", {"ENVIRONMENT": "prod"}):
+            resp = client.post("/api/v1/debug/test-push-notification")
+            assert resp.status_code == 403
+
+    @patch("handlers.api_handler._is_admin_user", return_value=True)
+    @patch("boto3.client")
+    def test_debug_trigger_allowed_in_prod_for_admin(
+        self, mock_boto3_client, mock_admin, client
+    ):
+        """Debug trigger-notifications should be allowed for admin users in prod."""
+        mock_lambda = MagicMock()
+        mock_boto3_client.return_value = mock_lambda
+        mock_lambda.invoke.return_value = {"StatusCode": 202}
+        with patch.dict("os.environ", {"ENVIRONMENT": "prod"}):
+            resp = client.post("/api/v1/debug/trigger-notifications")
+            assert resp.status_code == 200
+
+    @patch("boto3.client")
+    def test_debug_trigger_allowed_in_staging(self, mock_boto3_client, client):
+        """Debug trigger-notifications should be allowed in staging."""
+        mock_lambda = MagicMock()
+        mock_boto3_client.return_value = mock_lambda
+        mock_lambda.invoke.return_value = {"StatusCode": 202}
+        with patch.dict("os.environ", {"ENVIRONMENT": "staging"}):
+            resp = client.post("/api/v1/debug/trigger-notifications")
+            assert resp.status_code == 200
+
+    def test_check_debug_access_non_prod(self):
+        """_check_debug_access should not raise for non-prod environments."""
+        from handlers.api_handler import _check_debug_access
+
+        # Should not raise for staging/dev
+        _check_debug_access("staging", None)
+        _check_debug_access("dev", None)
+
+    def test_check_debug_access_prod_no_user(self):
+        """_check_debug_access should raise HTTPException for prod with no user."""
+        from fastapi import HTTPException
+
+        from handlers.api_handler import _check_debug_access
+
+        with pytest.raises(HTTPException) as exc_info:
+            _check_debug_access("prod", None)
+        assert exc_info.value.status_code == 403
+
+    @patch("handlers.api_handler._is_admin_user", return_value=False)
+    def test_check_debug_access_prod_non_admin(self, mock_admin):
+        """_check_debug_access should raise HTTPException for prod with non-admin user."""
+        from fastapi import HTTPException
+
+        from handlers.api_handler import _check_debug_access
+
+        with pytest.raises(HTTPException) as exc_info:
+            _check_debug_access("prod", "some-user-id")
+        assert exc_info.value.status_code == 403

--- a/infrastructure/__main__.py
+++ b/infrastructure/__main__.py
@@ -527,6 +527,7 @@ weather_processor_lambda = aws.lambda_.Function(
             # Static JSON API generation (uploads to website bucket)
             "ENABLE_STATIC_JSON": config.get("enableStaticJson") or "true",
             "WEBSITE_BUCKET": website_bucket_name,
+            "SNOW_SUMMARY_TABLE": f"{app_name}-snow-summary-{environment}",
             "DAILY_HISTORY_TABLE": f"{app_name}-daily-history-{environment}",
             # Multi-source weather data
             "ENABLE_SNOWFORECAST": config.get("enableSnowForecast") or "false",
@@ -572,6 +573,7 @@ weather_worker_lambda = aws.lambda_.Function(
             "WEATHER_CONDITIONS_TABLE": f"{app_name}-weather-conditions-{environment}",
             "AWS_REGION_NAME": aws_region,
             "ENABLE_SCRAPING": "true",
+            "SNOW_SUMMARY_TABLE": f"{app_name}-snow-summary-{environment}",
             "DAILY_HISTORY_TABLE": f"{app_name}-daily-history-{environment}",
             "WEBSITE_BUCKET": website_bucket_name,
             # Multi-source weather data
@@ -1320,7 +1322,12 @@ def get_conditions(resort_id, headers):
             "CHAT_TABLE": f"{app_name}-chat-{environment}",
             "CHAT_RATE_LIMIT_TABLE_NAME": chat_rate_limit_table.name,
             "CONDITION_REPORTS_TABLE": f"{app_name}-condition-reports-{environment}",
+            "SNOW_SUMMARY_TABLE": f"{app_name}-snow-summary-{environment}",
             "DAILY_HISTORY_TABLE": f"{app_name}-daily-history-{environment}",
+            "APNS_PLATFORM_APP_ARN": apns_platform_app_arn
+            if apns_platform_app_arn
+            else "",
+            "WEBSITE_BUCKET": website_bucket_name,
             "AWS_REGION_NAME": aws_region,
         }
     ),


### PR DESCRIPTION
## Summary
- **Snow history empty**: `DAILY_HISTORY_TABLE` env var was missing from weather worker, weather processor, and API handler Lambda functions in both prod and staging. The weather worker defaulted to `snow-tracker-daily-history-dev` (which doesn't exist), so all daily history writes silently failed. Also added missing `SNOW_SUMMARY_TABLE` to Pulumi infra for weather processor, weather worker, and API handler.
- **Debug notifications blocked on TestFlight**: Debug endpoints (`/api/v1/debug/test-push-notification` and `/api/v1/debug/trigger-notifications`) rejected all production requests with HTTP 403. TestFlight builds use the production API, so admin users testing via TestFlight always got blocked. Added admin user check via SHA256 email hash (same hash list as iOS `Configuration.swift`). Also fixed test notification using `APNS_SANDBOX` in prod (should be `APNS` for production push certificates).
- **Lambda env vars fixed immediately via AWS CLI** for all 6 Lambda functions (3 prod + 3 staging). Weather processor triggered and daily history table populated (122 -> 1066+ records).

## Test plan
- [x] Backend tests pass: 1563 tests (7 new for debug access control)
- [x] `curl api.powderchaserapp.com/api/v1/resorts/big-white/history` returns data
- [x] Daily history table populated (1066+ records)
- [ ] Verify debug notification works from TestFlight as admin user
- [ ] Verify non-admin users still get 403 on debug endpoints in prod

🤖 Generated with [Claude Code](https://claude.com/claude-code)