### PR TITLE
Switch 3 DynamoDB tables to on-demand billing

### DIFF
--- a/infrastructure/__main__.py
+++ b/infrastructure/__main__.py
@@ -125,9 +125,7 @@ resorts_table = aws.dynamodb.Table(
 weather_conditions_table = aws.dynamodb.Table(
     f"{app_name}-weather-conditions-{environment}",
     name=f"{app_name}-weather-conditions-{environment}",
-    billing_mode="PROVISIONED",
-    read_capacity=25,
-    write_capacity=5,
+    billing_mode="PAY_PER_REQUEST",
     hash_key="resort_id",
     range_key="timestamp",
     attributes=[
@@ -141,8 +139,6 @@ weather_conditions_table = aws.dynamodb.Table(
             "hash_key": "elevation_level",
             "range_key": "timestamp",
             "projection_type": "ALL",
-            "read_capacity": 25,
-            "write_capacity": 1,
         }
     ],
     ttl={"attribute_name": "ttl", "enabled": True},
@@ -201,9 +197,7 @@ device_tokens_table = aws.dynamodb.Table(
 snow_summary_table = aws.dynamodb.Table(
     f"{app_name}-snow-summary-{environment}",
     name=f"{app_name}-snow-summary-{environment}",
-    billing_mode="PROVISIONED",
-    read_capacity=5,
-    write_capacity=5,
+    billing_mode="PAY_PER_REQUEST",
     hash_key="resort_id",
     range_key="elevation_level",  # base, mid, top
     attributes=[
@@ -221,9 +215,7 @@ daily_history_table = aws.dynamodb.Table(
     name=f"{app_name}-daily-history-{environment}",
     hash_key="resort_id",
     range_key="date",
-    billing_mode="PROVISIONED",
-    read_capacity=5,
-    write_capacity=5,
+    billing_mode="PAY_PER_REQUEST",
     attributes=[
         {"name": "resort_id", "type": "S"},
         {"name": "date", "type": "S"},  # YYYY-MM-DD format


### PR DESCRIPTION
## Summary
- \`weather-conditions\`, \`snow-summary\`, and \`daily-history\` were PROVISIONED with auto-scaling, which auto-created 64 TargetTracking CloudWatch alarms (~\$6.40/mo) plus RCU-hours (\$4.66/mo).
- Switches all three to PAY_PER_REQUEST. Better fit for bursty hourly-batch traffic; eliminates the autoscaling alarms.
- Pulumi matches the live AWS state already changed via CLI; this just prevents \`pulumi up\` from reverting.

## Savings
- RCU/WCU: ~\$4.66/mo → ~\$1/mo (PAY_PER_REQUEST usage on our volume)
- Alarms: ~\$6.40/mo → \$0
- **Total: ~\$10/mo, ~\$120/yr**

## Test plan
- [ ] \`cd infrastructure && pulumi preview\` on staging shows no changes (tables already on-demand)
- [ ] Same on prod
- [ ] Watch DynamoDB ThrottledRequests in CloudWatch for 24h after merge; should stay at 0