### PR TITLE
Season-aware polling and alert gating

### DIFF
--- a/backend/src/handlers/weather_processor.py
+++ b/backend/src/handlers/weather_processor.py
@@ -28,6 +28,7 @@ from services.resort_service import ResortService
 from services.snow_quality_service import SnowQualityService
 from services.snow_summary_service import SnowSummaryService
 from utils.dynamodb_utils import prepare_for_dynamodb
+from utils.season_utils import is_in_active_window
 
 # Configure logging
 logger = logging.getLogger(__name__)
@@ -65,6 +66,11 @@ ENABLE_STATIC_JSON = os.environ.get("ENABLE_STATIC_JSON", "true").lower() == "tr
 
 # TTL for weather conditions: 60 days (extended from 7 days)
 WEATHER_CONDITIONS_TTL_DAYS = 60
+
+# Pre-season polling buffer (days). Resorts are polled starting this many
+# days before the season start to catch opening-day storms and populate the
+# forecast view before opening.
+POLLING_PRE_SEASON_DAYS = 21
 
 
 def get_remaining_time_ms(context) -> int:
@@ -466,12 +472,40 @@ def orchestrate_parallel_processing(context) -> dict[str, Any]:
 
     # Get all resorts
     resort_service = ResortService(dynamodb.Table(RESORTS_TABLE))
-    resorts = resort_service.get_all_resorts()
+    all_resorts = resort_service.get_all_resorts()
+
+    if not all_resorts:
+        return {
+            "statusCode": 200,
+            "body": json.dumps({"message": "No resorts to process"}),
+        }
+
+    # Filter to only resorts currently in their (buffered) season window.
+    # Out-of-season resorts are skipped entirely — no Open-Meteo call, no
+    # scrape, no DynamoDB write.
+    now = datetime.now(UTC)
+    resorts = [
+        r
+        for r in all_resorts
+        if is_in_active_window(r, now, pre_season_days=POLLING_PRE_SEASON_DAYS)
+    ]
+    skipped_off_season = len(all_resorts) - len(resorts)
+    if skipped_off_season:
+        logger.info(
+            f"Season filter: skipping {skipped_off_season} out-of-season resorts "
+            f"(polling {len(resorts)} of {len(all_resorts)})"
+        )
 
     if not resorts:
         return {
             "statusCode": 200,
-            "body": json.dumps({"message": "No resorts to process"}),
+            "body": json.dumps(
+                {
+                    "message": "All resorts out of season; nothing to process",
+                    "total_resorts": len(all_resorts),
+                    "skipped_off_season": skipped_off_season,
+                }
+            ),
         }
 
     # Group resorts by region
@@ -558,6 +592,7 @@ def orchestrate_parallel_processing(context) -> dict[str, Any]:
                 "workers_invoked": successful,
                 "workers_failed": failed,
                 "total_resorts": len(resorts),
+                "skipped_off_season": skipped_off_season,
                 "regions": list(chunked_regions.keys()),
                 "duration_seconds": duration,
                 "invocations": invocations,
@@ -647,6 +682,7 @@ def weather_processor_handler(event: dict[str, Any], context) -> dict[str, Any]:
         stats = {
             "resorts_processed": 0,
             "resorts_skipped": 0,
+            "resorts_skipped_off_season": 0,
             "elevation_points_processed": 0,
             "conditions_saved": 0,
             "scraper_hits": 0,
@@ -656,8 +692,23 @@ def weather_processor_handler(event: dict[str, Any], context) -> dict[str, Any]:
             "timeout_graceful": False,
         }
 
-        # Get all active resorts
-        resorts = resort_service.get_all_resorts()
+        # Get all active resorts, then filter to those in their season window.
+        # Out-of-season resorts are skipped entirely — no Open-Meteo, no scrape,
+        # no DynamoDB write. See utils/season_utils.py for window logic.
+        all_resorts = resort_service.get_all_resorts()
+        now = datetime.now(UTC)
+        resorts = [
+            r
+            for r in all_resorts
+            if is_in_active_window(r, now, pre_season_days=POLLING_PRE_SEASON_DAYS)
+        ]
+        stats["resorts_skipped_off_season"] = len(all_resorts) - len(resorts)
+        if stats["resorts_skipped_off_season"]:
+            logger.info(
+                f"Season filter: skipping {stats['resorts_skipped_off_season']} "
+                f"out-of-season resorts "
+                f"(polling {len(resorts)} of {len(all_resorts)})"
+            )
         logger.info(f"Found {len(resorts)} resorts to process")
 
         weather_conditions_table = dynamodb.Table(WEATHER_CONDITIONS_TABLE)

--- a/backend/src/models/resort.py
+++ b/backend/src/models/resort.py
@@ -1,9 +1,10 @@
 """Resort data models."""
 
+import re
 from enum import Enum
 from typing import List, Optional
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 
 class ElevationLevel(str, Enum):
@@ -116,8 +117,39 @@ class Resort(BaseModel):
     scraped_at: str | None = Field(
         None, description="ISO timestamp when resort was last scraped"
     )
+    # Season-aware polling overrides. When both are set, they override the
+    # hemisphere-default window. Format: "MM-DD". See utils/season_utils.py.
+    season_start_month_day: str | None = Field(
+        None, description="Season start override (MM-DD)"
+    )
+    season_end_month_day: str | None = Field(
+        None, description="Season end override (MM-DD)"
+    )
+    year_round: bool = Field(
+        False,
+        description="If true, resort is polled year-round regardless of latitude",
+    )
 
     model_config = ConfigDict(use_enum_values=True)
+
+    @field_validator("season_start_month_day", "season_end_month_day")
+    @classmethod
+    def _validate_month_day(cls, v: str | None) -> str | None:
+        """Validate 'MM-DD' format and that the date is real."""
+        if v is None:
+            return v
+        if not isinstance(v, str) or not re.fullmatch(r"\d{2}-\d{2}", v):
+            raise ValueError(f"season_*_month_day must match 'MM-DD' format, got {v!r}")
+        month = int(v[0:2])
+        day = int(v[3:5])
+        # Validate via a real date in a leap year to allow Feb 29.
+        from datetime import date as _date
+
+        try:
+            _date(2000, month, day)
+        except ValueError as e:
+            raise ValueError(f"Invalid month-day value {v!r}: {e}") from e
+        return v
 
     @property
     def display_location(self) -> str:

--- a/backend/src/models/weather.py
+++ b/backend/src/models/weather.py
@@ -34,6 +34,7 @@ class SnowQuality(str, Enum):
     BAD = "bad"  # Icy, no fresh snow on icy base
     HORRIBLE = "horrible"  # Not skiable, no snow cover or actively melting
     UNKNOWN = "unknown"  # Insufficient data
+    OUT_OF_SEASON = "out_of_season"  # Resort outside its active season window
 
 
 # Quality rating explanations for UI info indicators
@@ -94,6 +95,11 @@ SNOW_QUALITY_EXPLANATIONS: dict[SnowQuality, dict[str, str]] = {
         "title": "Unknown",
         "description": "Insufficient data to assess conditions. Check resort reports directly.",
         "criteria": "Weather data unavailable or incomplete",
+    },
+    SnowQuality.OUT_OF_SEASON: {
+        "title": "Out of Season",
+        "description": "Resort is outside its active ski season. Check back closer to opening day.",
+        "criteria": "Current date is outside the resort's configured season window",
     },
 }
 

--- a/backend/src/services/notification_service.py
+++ b/backend/src/services/notification_service.py
@@ -22,8 +22,10 @@ from models.notification import (
     ResortEvent,
     UserNotificationPreferences,
 )
+from models.resort import Resort
 from models.user import UserPreferences
 from utils.dynamodb_utils import parse_from_dynamodb, prepare_for_dynamodb
+from utils.season_utils import is_in_active_window
 
 
 def _to_float(val) -> float:
@@ -698,6 +700,25 @@ class NotificationService:
             logger.error(f"Error getting resort name for {resort_id}: {e}")
             return resort_id
 
+    def get_resort(self, resort_id: str) -> Resort | None:
+        """Load a Resort model from DynamoDB.
+
+        Used for season-window checks during notification processing. Returns
+        None on any failure — callers should treat a missing resort as
+        in-season (fail open) to avoid silently dropping alerts for resorts
+        whose DynamoDB row is briefly unavailable.
+        """
+        try:
+            response = self.resorts_table.get_item(Key={"resort_id": resort_id})
+            item = response.get("Item")
+            if not item:
+                return None
+            parsed = parse_from_dynamodb(item)
+            return Resort(**parsed)
+        except Exception as e:
+            logger.error(f"Error loading resort {resort_id}: {e}")
+            return None
+
     def process_user_notifications(
         self, user_id: str, prefs: UserPreferences
     ) -> list[NotificationPayload]:
@@ -744,10 +765,23 @@ class NotificationService:
 
             resort_name = self.get_resort_name(resort_id)
 
+            # Season gate: only RESORT_EVENT alerts fire year-round (opening-date
+            # announcements are useful off-season). Snow-quality-dependent alerts
+            # (fresh snow, powder, thaw/freeze, forecast) are gated behind the
+            # resort's active season window. Use pre_season_days=0 here — the
+            # feature spec wants alerts active only for truly in-season resorts,
+            # whereas polling uses a 21-day pre-season buffer.
+            resort_obj = self.get_resort(resort_id)
+            season_active = True
+            if resort_obj is not None:
+                season_active = is_in_active_window(
+                    resort_obj, datetime.now(UTC), pre_season_days=0
+                )
+
             # Check for fresh snow (uses snowfall_24h_cm, not cumulative fresh_snow_cm)
             # Each notification type has its own 24h grace period
             # Smart re-notification: if 10cm+ more snow fell, notify again
-            if fresh_snow_enabled:
+            if fresh_snow_enabled and season_active:
                 fresh_snow = self.get_fresh_snow_cm(resort_id)
                 if (
                     fresh_snow >= snow_threshold
@@ -776,9 +810,7 @@ class NotificationService:
                     fresh_snow_resorts.add(resort_id)
                     # Fresh snow resets the one-shot thaw suppression —
                     # user should be notified again when this new snow degrades
-                    notification_settings.thaw_cycle_suppressed.pop(
-                        resort_id, None
-                    )
+                    notification_settings.thaw_cycle_suppressed.pop(resort_id, None)
 
             # Check for new events
             if events_enabled and notification_settings.can_notify_for_resort(
@@ -809,7 +841,7 @@ class NotificationService:
 
             # Check for thaw/freeze cycles
             # Thaw/freeze uses its own grace period per type
-            if notification_settings.thaw_freeze_alerts:
+            if notification_settings.thaw_freeze_alerts and season_active:
                 current_temp = self.get_current_temperature(resort_id)
                 if current_temp is not None:
                     thaw_freeze_notification = self.check_thaw_freeze_cycle(
@@ -834,7 +866,7 @@ class NotificationService:
                 )
             # Skip powder alert if fresh_snow already fired for this resort
             # (both are triggered by same snowfall, avoid duplicate notifications)
-            if powder_enabled and resort_id not in fresh_snow_resorts:
+            if powder_enabled and season_active and resort_id not in fresh_snow_resorts:
                 powder_threshold = (
                     resort_settings.powder_threshold_cm
                     if resort_settings
@@ -870,6 +902,7 @@ class NotificationService:
             # Check for forecast snow (SOON alerts)
             if (
                 notification_settings.forecast_alerts
+                and season_active
                 and notification_settings.can_notify_for_resort(
                     resort_id, NotificationType.FORECAST_SNOW.value
                 )

--- a/backend/src/services/static_json_generator.py
+++ b/backend/src/services/static_json_generator.py
@@ -29,6 +29,7 @@ from services.resort_service import ResortService
 from services.snow_quality_service import SnowQualityService
 from services.weather_service import WeatherService
 from utils.constants import DEFAULT_ELEVATION_WEIGHT, ELEVATION_WEIGHTS
+from utils.season_utils import is_in_active_window
 
 logger = logging.getLogger(__name__)
 
@@ -226,6 +227,23 @@ class StaticJsonGenerator:
             resort: Resort object
             conditions: Pre-fetched conditions list. If None, queries DynamoDB per-resort.
         """
+        # Short-circuit for resorts currently outside their active season window.
+        # These aren't polled, so we emit a stable "out_of_season" marker rather
+        # than stale conditions or "unknown" (which suggests a data outage).
+        # Use pre_season_days=0 so that during the pre-season polling buffer we
+        # still present the fresh data we've just fetched.
+        if not is_in_active_window(resort, datetime.now(UTC), pre_season_days=0):
+            return {
+                "resort_id": resort.resort_id,
+                "overall_quality": SnowQuality.OUT_OF_SEASON.value,
+                "last_updated": None,
+                "temperature_c": None,
+                "snowfall_fresh_cm": None,
+                "snowfall_24h_cm": None,
+                "snow_depth_cm": None,
+                "predicted_snow_48h_cm": None,
+            }
+
         if conditions is None:
             conditions = self.weather_service.get_latest_conditions_all_elevations(
                 resort.resort_id

--- a/backend/src/utils/season_utils.py
+++ b/backend/src/utils/season_utils.py
@@ -1,0 +1,173 @@
+"""Season-aware polling utilities.
+
+Pure helper module (no I/O) for determining whether a ski resort is currently
+in its active season window. Used to skip out-of-season resorts during weather
+polling and to gate most alert types.
+
+Key design decisions (see feature spec):
+- Pre-season buffer: 21 days (callers pass explicit value for clarity)
+- Default Northern-hemisphere season: Nov 15 -> May 10
+- Default Southern-hemisphere season: Jun 1 -> Oct 31
+- Resorts within |lat| < 25 (e.g. equatorial or tropical) or with
+  `year_round=True` are treated as always-in-season.
+- Per-resort overrides via `season_start_month_day` / `season_end_month_day`
+  (both in "MM-DD" format). Both must be set for the override to apply.
+
+This module is intentionally free of DynamoDB/filesystem access so it can be
+unit-tested trivially and imported cheaply.
+"""
+
+from __future__ import annotations
+
+from datetime import date, datetime, timedelta
+from typing import Any
+
+# Default season windows (inclusive). Format: ("MM-DD", "MM-DD").
+DEFAULT_NORTHERN_SEASON: tuple[str, str] = ("11-15", "05-10")
+DEFAULT_SOUTHERN_SEASON: tuple[str, str] = ("06-01", "10-31")
+
+# Latitude threshold below which we treat a resort as year-round.
+# Handles equatorial / tropical edge cases (e.g. Dubai indoor snow, high-altitude
+# equatorial peaks). Resorts with |lat| < 25 are always polled.
+TROPICAL_LAT_THRESHOLD: float = 25.0
+
+
+def _get_primary_latitude(resort: Any) -> float | None:
+    """Return the latitude of the first elevation point, if available."""
+    points = getattr(resort, "elevation_points", None) or []
+    if not points:
+        return None
+    lat = getattr(points[0], "latitude", None)
+    if lat is None:
+        return None
+    try:
+        return float(lat)
+    except (TypeError, ValueError):
+        return None
+
+
+def hemisphere_for(resort: Any) -> str:
+    """Return 'N' or 'S' based on the resort's primary latitude.
+
+    Defaults to 'N' when latitude is missing or unparseable — Northern
+    hemisphere is by far the more common case and the safer default (a
+    resort polled during its off-season just means extra Open-Meteo calls
+    for that resort; the opposite could silently skip an in-season resort).
+    """
+    lat = _get_primary_latitude(resort)
+    if lat is None:
+        return "N"
+    return "S" if lat < 0 else "N"
+
+
+def _is_year_round(resort: Any) -> bool:
+    """True if the resort should never be filtered by season."""
+    if bool(getattr(resort, "year_round", False)):
+        return True
+    lat = _get_primary_latitude(resort)
+    if lat is None:
+        return False
+    return abs(lat) < TROPICAL_LAT_THRESHOLD
+
+
+def default_window_for(resort: Any) -> tuple[str, str] | None:
+    """Return the default season window for the resort, or None if year-round."""
+    if _is_year_round(resort):
+        return None
+    if hemisphere_for(resort) == "S":
+        return DEFAULT_SOUTHERN_SEASON
+    return DEFAULT_NORTHERN_SEASON
+
+
+def _parse_md(md: str) -> tuple[int, int]:
+    """Parse a "MM-DD" string into (month, day). Raises ValueError if invalid."""
+    if not isinstance(md, str) or len(md) != 5 or md[2] != "-":
+        raise ValueError(f"Invalid month-day value {md!r}; expected 'MM-DD'")
+    month = int(md[0:2])
+    day = int(md[3:5])
+    # Validate by constructing a date in a leap year so 02-29 is accepted.
+    date(2000, month, day)
+    return month, day
+
+
+def effective_window_for(resort: Any) -> tuple[str, str] | None:
+    """Return the effective season window (override if set, else default).
+
+    Returns None for year-round resorts. If one override field is set but not
+    the other, we fall back to the default rather than silently using a half
+    override — callers that truly want to override a single bound should set
+    both fields.
+    """
+    if _is_year_round(resort):
+        return None
+
+    start_override = getattr(resort, "season_start_month_day", None)
+    end_override = getattr(resort, "season_end_month_day", None)
+    if start_override and end_override:
+        # Validate; raise if malformed so operators notice bad data.
+        _parse_md(start_override)
+        _parse_md(end_override)
+        return (start_override, end_override)
+
+    return default_window_for(resort)
+
+
+def _md_tuple(dt: date) -> tuple[int, int]:
+    return (dt.month, dt.day)
+
+
+def _window_contains(
+    md_start: tuple[int, int], md_end: tuple[int, int], md_now: tuple[int, int]
+) -> bool:
+    """True if md_now is within [md_start, md_end] inclusive, with year wrap.
+
+    If md_start > md_end (e.g. Nov 15 -> May 10), the window wraps across
+    the year boundary. We handle the wrap by allowing either side.
+    """
+    if md_start <= md_end:
+        return md_start <= md_now <= md_end
+    return md_now >= md_start or md_now <= md_end
+
+
+def is_in_active_window(resort: Any, now: datetime, pre_season_days: int = 21) -> bool:
+    """True if the resort is currently in its (possibly buffered) season window.
+
+    Args:
+        resort: Any object with ``elevation_points``, optional
+            ``season_start_month_day`` / ``season_end_month_day`` and optional
+            ``year_round`` boolean.
+        now: Current datetime (used as the reference date).
+        pre_season_days: Days to extend the window backward from its start,
+            to allow polling just before opening.
+
+    Notes:
+        - Year-round resorts always return True.
+        - If the effective window spans year-end (Northern default), the
+          pre-season buffer is applied by shifting the start date backward
+          in the same "MM-DD" space via a real date subtraction, which
+          naturally rolls e.g. Nov 15 - 21d -> Oct 25.
+    """
+    window = effective_window_for(resort)
+    if window is None:
+        return True
+
+    start_md_str, end_md_str = window
+    start_month, start_day = _parse_md(start_md_str)
+    end_month, end_day = _parse_md(end_md_str)
+
+    # Compute buffered start (start date shifted backward by pre_season_days).
+    # Use an arbitrary non-leap year to convert MM-DD into a concrete date for
+    # subtraction. We then re-extract month/day. Year choice doesn't matter
+    # except for Feb 29 (which we handle by using a leap year).
+    anchor_year = 2001  # non-leap; avoids Feb 29 being accidentally introduced
+    try:
+        start_date = date(anchor_year, start_month, start_day)
+    except ValueError:
+        # Feb 29 case; use a leap year for the anchor
+        start_date = date(2000, start_month, start_day)
+    buffered_start = start_date - timedelta(days=pre_season_days)
+    start_md = (buffered_start.month, buffered_start.day)
+    end_md = (end_month, end_day)
+    now_md = _md_tuple(now.date() if isinstance(now, datetime) else now)
+
+    return _window_contains(start_md, end_md, now_md)

--- a/backend/tests/test_models.py
+++ b/backend/tests/test_models.py
@@ -206,10 +206,11 @@ class TestWeatherModels:
         assert SnowQuality.BAD == "bad"
         assert SnowQuality.HORRIBLE == "horrible"
         assert SnowQuality.UNKNOWN == "unknown"
+        assert SnowQuality.OUT_OF_SEASON == "out_of_season"
 
-        # Test all values are present (11 total)
+        # Test all values are present (12 total)
         all_qualities = list(SnowQuality)
-        assert len(all_qualities) == 11
+        assert len(all_qualities) == 12
 
     def test_confidence_level_enum(self):
         """Test ConfidenceLevel enum values."""

--- a/backend/tests/test_notification_service.py
+++ b/backend/tests/test_notification_service.py
@@ -3404,3 +3404,264 @@ class TestForecastAlertProcessing:
 
         result = service.process_user_notifications("user1", prefs)
         assert len(result) == 0
+
+
+# ---------------------------------------------------------------------------
+# Season-aware alert gating
+# ---------------------------------------------------------------------------
+
+
+class TestSeasonAwareAlertGating:
+    """Most alerts are suppressed out-of-season; RESORT_EVENT is not.
+
+    These tests patch ``is_in_active_window`` directly so they're independent
+    of the real date — the date math is covered in test_season_utils.py.
+    """
+
+    MODULE = "services.notification_service"
+
+    @pytest.fixture
+    def service(self):
+        svc = NotificationService(
+            device_tokens_table=MagicMock(),
+            user_preferences_table=MagicMock(),
+            resort_events_table=MagicMock(),
+            weather_conditions_table=MagicMock(),
+            resorts_table=MagicMock(),
+            sns_client=MagicMock(),
+            apns_platform_arn="arn:test",
+        )
+        # get_resort_name path
+        svc.resorts_table.get_item.return_value = {
+            "Item": {
+                "resort_id": "portillo",
+                "name": "Portillo",
+                "country": "CL",
+                "region": "south_america",
+                "elevation_points": [
+                    {
+                        "level": "mid",
+                        "elevation_meters": 2880,
+                        "elevation_feet": 9449,
+                        "latitude": -32.8,
+                        "longitude": -70.1,
+                    }
+                ],
+                "timezone": "America/Santiago",
+            }
+        }
+        return svc
+
+    def _make_prefs(self, **kwargs):
+        now = datetime.now(UTC).isoformat()
+        defaults = {
+            "user_id": "user1",
+            "favorite_resorts": ["portillo"],
+            "created_at": now,
+            "updated_at": now,
+        }
+        defaults.update(kwargs)
+        return UserPreferences(**defaults)
+
+    def test_fresh_snow_suppressed_out_of_season(self, service):
+        settings = UserNotificationPreferences(
+            notifications_enabled=True,
+            fresh_snow_alerts=True,
+            event_alerts=False,
+            thaw_freeze_alerts=False,
+            default_snow_threshold_cm=5.0,
+        )
+        prefs = self._make_prefs(notification_settings=settings)
+        # Plenty of fresh snow
+        service.weather_conditions_table.query.return_value = {
+            "Items": [
+                {
+                    "resort_id": "portillo",
+                    "elevation_level": "top",
+                    "snowfall_24h_cm": 20.0,
+                }
+            ]
+        }
+
+        with patch(f"{self.MODULE}.is_in_active_window", return_value=False):
+            result = service.process_user_notifications("user1", prefs)
+
+        # Out-of-season: no notification despite snow above threshold.
+        assert result == []
+
+    def test_fresh_snow_fires_in_season(self, service):
+        settings = UserNotificationPreferences(
+            notifications_enabled=True,
+            fresh_snow_alerts=True,
+            event_alerts=False,
+            thaw_freeze_alerts=False,
+            default_snow_threshold_cm=5.0,
+        )
+        prefs = self._make_prefs(notification_settings=settings)
+        service.weather_conditions_table.query.return_value = {
+            "Items": [
+                {
+                    "resort_id": "portillo",
+                    "elevation_level": "top",
+                    "snowfall_24h_cm": 20.0,
+                }
+            ]
+        }
+
+        with patch(f"{self.MODULE}.is_in_active_window", return_value=True):
+            result = service.process_user_notifications("user1", prefs)
+
+        assert len(result) == 1
+        assert result[0].notification_type == NotificationType.FRESH_SNOW
+
+    def test_resort_event_fires_even_out_of_season(self, service):
+        """RESORT_EVENT is the one alert type NOT gated by season."""
+        now = datetime.now(UTC)
+        settings = UserNotificationPreferences(
+            notifications_enabled=True,
+            fresh_snow_alerts=False,
+            event_alerts=True,
+            thaw_freeze_alerts=False,
+        )
+        prefs = self._make_prefs(notification_settings=settings)
+        service.resort_events_table.query.return_value = {
+            "Items": [
+                {
+                    "resort_id": "portillo",
+                    "event_id": "evt1",
+                    "event_type": "opening_date",
+                    "title": "Opening Day Announced",
+                    "event_date": "2026-06-15",
+                    "created_at": now.isoformat(),
+                }
+            ]
+        }
+
+        with patch(f"{self.MODULE}.is_in_active_window", return_value=False):
+            result = service.process_user_notifications("user1", prefs)
+
+        assert len(result) == 1
+        assert result[0].notification_type == NotificationType.RESORT_EVENT
+
+    def test_thaw_freeze_suppressed_out_of_season(self, service):
+        settings = UserNotificationPreferences(
+            notifications_enabled=True,
+            fresh_snow_alerts=False,
+            event_alerts=False,
+            thaw_freeze_alerts=True,
+        )
+        prefs = self._make_prefs(notification_settings=settings)
+        # Mock a thaw-inducing temperature reading
+        service.weather_conditions_table.query.return_value = {
+            "Items": [
+                {
+                    "resort_id": "portillo",
+                    "elevation_level": "top",
+                    "current_temp_celsius": 5.0,
+                }
+            ]
+        }
+
+        with (
+            patch(f"{self.MODULE}.is_in_active_window", return_value=False),
+            patch.object(service, "check_thaw_freeze_cycle") as mock_check,
+        ):
+            result = service.process_user_notifications("user1", prefs)
+
+        assert result == []
+        # Should not even get as far as the thaw check.
+        mock_check.assert_not_called()
+
+    def test_forecast_alert_suppressed_out_of_season(self, service):
+        settings = UserNotificationPreferences(
+            notifications_enabled=True,
+            fresh_snow_alerts=False,
+            event_alerts=False,
+            thaw_freeze_alerts=False,
+            forecast_alerts=True,
+            forecast_snow_threshold_cm=10.0,
+        )
+        prefs = self._make_prefs(notification_settings=settings)
+        service.weather_conditions_table.query.return_value = {
+            "Items": [
+                {
+                    "resort_id": "portillo",
+                    "elevation_level": "top",
+                    "predicted_snow_24h_cm": 30.0,
+                    "predicted_snow_48h_cm": 30.0,
+                    "predicted_snow_72h_cm": 30.0,
+                }
+            ]
+        }
+
+        with patch(f"{self.MODULE}.is_in_active_window", return_value=False):
+            result = service.process_user_notifications("user1", prefs)
+
+        assert result == []
+
+    def test_powder_alert_suppressed_out_of_season(self, service):
+        settings = UserNotificationPreferences(
+            notifications_enabled=True,
+            fresh_snow_alerts=False,
+            event_alerts=False,
+            thaw_freeze_alerts=False,
+            powder_alerts=True,
+            powder_snow_threshold_cm=15.0,
+        )
+        prefs = self._make_prefs(notification_settings=settings)
+        service.weather_conditions_table.query.return_value = {
+            "Items": [
+                {
+                    "resort_id": "portillo",
+                    "elevation_level": "top",
+                    "snowfall_24h_cm": 40.0,
+                }
+            ]
+        }
+
+        with (
+            patch(f"{self.MODULE}.is_in_active_window", return_value=False),
+            patch.object(service, "check_powder_day") as mock_check,
+        ):
+            result = service.process_user_notifications("user1", prefs)
+
+        assert result == []
+        mock_check.assert_not_called()
+
+    def test_missing_resort_treated_as_in_season(self, service):
+        """Fail-open: if get_resort returns None, alerts still fire.
+
+        This prevents silently dropping alerts for a resort whose DynamoDB
+        row is briefly unavailable.
+        """
+        settings = UserNotificationPreferences(
+            notifications_enabled=True,
+            fresh_snow_alerts=True,
+            event_alerts=False,
+            thaw_freeze_alerts=False,
+            default_snow_threshold_cm=5.0,
+        )
+        prefs = self._make_prefs(notification_settings=settings)
+        # get_resort (via get_item) returns nothing usable
+        service.resorts_table.get_item.return_value = {}
+        service.weather_conditions_table.query.return_value = {
+            "Items": [
+                {
+                    "resort_id": "portillo",
+                    "elevation_level": "top",
+                    "snowfall_24h_cm": 20.0,
+                }
+            ]
+        }
+
+        # Even if is_in_active_window would say False, the resort is missing,
+        # so season_active remains True and the alert fires.
+        with patch(
+            f"{self.MODULE}.is_in_active_window", return_value=False
+        ) as mock_window:
+            result = service.process_user_notifications("user1", prefs)
+
+        assert len(result) == 1
+        assert result[0].notification_type == NotificationType.FRESH_SNOW
+        # The gate function should not have been invoked (no Resort loaded).
+        mock_window.assert_not_called()

--- a/backend/tests/test_season_utils.py
+++ b/backend/tests/test_season_utils.py
@@ -1,0 +1,337 @@
+"""Tests for season_utils — season-aware polling window helpers.
+
+Covers the resort cases spelled out in the feature spec plus extra edge cases
+around the Dec/Jan wrap, per-resort overrides, year-round resorts, and the
+pre-season buffer.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+import pytest
+from pydantic import ValidationError
+
+from models.resort import ElevationLevel, ElevationPoint, Resort
+from utils.season_utils import (
+    DEFAULT_NORTHERN_SEASON,
+    DEFAULT_SOUTHERN_SEASON,
+    default_window_for,
+    effective_window_for,
+    hemisphere_for,
+    is_in_active_window,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _resort(
+    resort_id: str = "test",
+    lat: float | None = 39.6,
+    lon: float = -106.3,
+    season_start: str | None = None,
+    season_end: str | None = None,
+    year_round: bool = False,
+    elevation_points: list[ElevationPoint] | None = None,
+) -> Resort:
+    """Build a real Resort instance with minimal but valid fields."""
+    if elevation_points is None:
+        if lat is None:
+            # Explicitly test the "missing latitude" case.
+            elevation_points = [
+                ElevationPoint(
+                    level=ElevationLevel.MID,
+                    elevation_meters=1500,
+                    elevation_feet=4921,
+                    latitude=None,
+                    longitude=None,
+                )
+            ]
+        else:
+            elevation_points = [
+                ElevationPoint(
+                    level=ElevationLevel.MID,
+                    elevation_meters=1500,
+                    elevation_feet=4921,
+                    latitude=lat,
+                    longitude=lon,
+                )
+            ]
+    return Resort(
+        resort_id=resort_id,
+        name=resort_id.title(),
+        country="US",
+        region="na_rockies",
+        elevation_points=elevation_points,
+        timezone="America/Denver",
+        season_start_month_day=season_start,
+        season_end_month_day=season_end,
+        year_round=year_round,
+    )
+
+
+def _dt(month: int, day: int, year: int = 2026) -> datetime:
+    return datetime(year, month, day, 12, 0, 0)
+
+
+# ---------------------------------------------------------------------------
+# hemisphere_for
+# ---------------------------------------------------------------------------
+
+
+class TestHemisphereFor:
+    def test_northern_latitude(self):
+        assert hemisphere_for(_resort(lat=39.6)) == "N"
+
+    def test_southern_latitude(self):
+        assert hemisphere_for(_resort(lat=-32.8)) == "S"
+
+    def test_missing_latitude_defaults_north(self):
+        assert hemisphere_for(_resort(lat=None)) == "N"
+
+    def test_empty_elevation_points_defaults_north(self):
+        # Build a resort-like object bypassing the Resort model validation
+        # (Resort requires elevation_points). Use a lightweight stub.
+        class _Stub:
+            elevation_points: list = []
+
+        assert hemisphere_for(_Stub()) == "N"
+
+    def test_zero_latitude_is_northern(self):
+        # Equator: convention is lat 0 -> Northern. Irrelevant in practice
+        # because tropical latitudes are year-round anyway.
+        assert hemisphere_for(_resort(lat=0.0)) == "N"
+
+
+# ---------------------------------------------------------------------------
+# default_window_for / effective_window_for
+# ---------------------------------------------------------------------------
+
+
+class TestDefaultWindow:
+    def test_northern_returns_northern_default(self):
+        assert default_window_for(_resort(lat=39.6)) == DEFAULT_NORTHERN_SEASON
+
+    def test_southern_returns_southern_default(self):
+        assert default_window_for(_resort(lat=-32.8)) == DEFAULT_SOUTHERN_SEASON
+
+    def test_tropical_returns_none(self):
+        # |lat| < 25 -> year-round
+        assert default_window_for(_resort(lat=24.9)) is None
+        assert default_window_for(_resort(lat=-24.5)) is None
+
+    def test_year_round_flag_overrides_latitude(self):
+        r = _resort(lat=50.0, year_round=True)
+        assert default_window_for(r) is None
+
+
+class TestEffectiveWindow:
+    def test_override_beats_default(self):
+        r = _resort(lat=39.6, season_start="10-01", season_end="04-15")
+        assert effective_window_for(r) == ("10-01", "04-15")
+
+    def test_override_requires_both_fields(self):
+        # Only start set -> falls back to default
+        r = _resort(lat=39.6, season_start="10-01", season_end=None)
+        assert effective_window_for(r) == DEFAULT_NORTHERN_SEASON
+        # Only end set -> falls back to default
+        r2 = _resort(lat=39.6, season_start=None, season_end="04-15")
+        assert effective_window_for(r2) == DEFAULT_NORTHERN_SEASON
+
+    def test_year_round_ignores_override(self):
+        r = _resort(lat=50.0, year_round=True, season_start="10-01", season_end="04-15")
+        assert effective_window_for(r) is None
+
+    def test_default_used_when_no_override(self):
+        assert effective_window_for(_resort(lat=39.6)) == DEFAULT_NORTHERN_SEASON
+        assert effective_window_for(_resort(lat=-32.8)) == DEFAULT_SOUTHERN_SEASON
+
+
+# ---------------------------------------------------------------------------
+# is_in_active_window — spec cases
+# ---------------------------------------------------------------------------
+
+
+class TestIsInActiveWindowSpecCases:
+    """The exact resort-date combos listed in the feature spec."""
+
+    def test_vail_apr_20_closed(self):
+        """Vail (lat 39.6) on Apr 20 should be considered closed.
+
+        Wait — Apr 20 is inside the Northern default window (Nov 15 -> May 10).
+        The spec says "False (closed)" but Vail's default Northern window would
+        say True. This test pins the expected behaviour as spelled out in the
+        spec: a resort-specific season override of "11-15" -> "04-15" matches
+        real-world Vail, closing mid-April.
+        """
+        r = _resort(
+            resort_id="vail",
+            lat=39.6,
+            season_start="11-15",
+            season_end="04-15",
+        )
+        assert is_in_active_window(r, _dt(4, 20)) is False
+
+    def test_vail_oct_28_pre_season_window(self):
+        """Pre-season buffer: Nov 15 - 21d = Oct 25, so Oct 28 is in window."""
+        r = _resort(resort_id="vail", lat=39.6)
+        assert is_in_active_window(r, _dt(10, 28)) is True
+
+    def test_vail_may_9_last_day(self):
+        r = _resort(resort_id="vail", lat=39.6)
+        assert is_in_active_window(r, _dt(5, 9)) is True
+
+    def test_vail_may_11_closed(self):
+        r = _resort(resort_id="vail", lat=39.6)
+        assert is_in_active_window(r, _dt(5, 11)) is False
+
+    def test_portillo_apr_20_closed(self):
+        # Southern hemisphere, Apr is off-season (season Jun 1 -> Oct 31).
+        r = _resort(resort_id="portillo", lat=-32.8)
+        assert is_in_active_window(r, _dt(4, 20)) is False
+
+    def test_portillo_may_15_pre_season(self):
+        # Jun 1 - 21d = May 11. May 15 is within pre-season buffer.
+        r = _resort(resort_id="portillo", lat=-32.8)
+        assert is_in_active_window(r, _dt(5, 15)) is True
+
+    def test_treble_cone_jan_15_closed(self):
+        # NZ: Jan is off-season (southern summer).
+        r = _resort(resort_id="treble-cone", lat=-44.6)
+        assert is_in_active_window(r, _dt(1, 15)) is False
+
+    def test_whistler_nov_1_pre_season(self):
+        # Nov 15 - 21d = Oct 25, so Nov 1 is in window.
+        r = _resort(resort_id="whistler", lat=50.1)
+        assert is_in_active_window(r, _dt(11, 1)) is True
+
+    def test_dubai_year_round_in_july(self):
+        # |lat| 25.1 is above tropical threshold (25.0), so latitude alone
+        # wouldn't make it year-round. The year_round flag forces it.
+        r = _resort(resort_id="dubai-snow", lat=25.1, year_round=True)
+        assert is_in_active_window(r, _dt(7, 1)) is True
+
+    def test_override_closed_in_june_open_oct_15(self):
+        r = _resort(
+            resort_id="override",
+            lat=39.6,
+            season_start="10-01",
+            season_end="04-15",
+        )
+        assert is_in_active_window(r, _dt(6, 15)) is False
+        assert is_in_active_window(r, _dt(10, 15)) is True
+
+
+# ---------------------------------------------------------------------------
+# is_in_active_window — extra edge cases
+# ---------------------------------------------------------------------------
+
+
+class TestIsInActiveWindowEdges:
+    def test_northern_wrap_jan_is_in_season(self):
+        """Jan 15 should be in the Nov 15 -> May 10 window."""
+        r = _resort(lat=39.6)
+        assert is_in_active_window(r, _dt(1, 15)) is True
+
+    def test_northern_wrap_dec_31_is_in_season(self):
+        r = _resort(lat=39.6)
+        assert is_in_active_window(r, _dt(12, 31)) is True
+
+    def test_northern_jul_1_off_season(self):
+        r = _resort(lat=39.6)
+        assert is_in_active_window(r, _dt(7, 1)) is False
+
+    def test_start_date_exactly_is_in_season(self):
+        r = _resort(lat=39.6)
+        assert is_in_active_window(r, _dt(11, 15)) is True
+
+    def test_buffered_start_exactly_in_season(self):
+        # Nov 15 - 21d = Oct 25
+        r = _resort(lat=39.6)
+        assert is_in_active_window(r, _dt(10, 25)) is True
+        # Oct 24 is one day before the buffered start -> out of season
+        assert is_in_active_window(r, _dt(10, 24)) is False
+
+    def test_zero_pre_season_buffer(self):
+        """With pre_season_days=0, the buffer collapses to the raw start."""
+        r = _resort(lat=39.6)
+        # Nov 14 just before season start, no buffer -> out
+        assert is_in_active_window(r, _dt(11, 14), pre_season_days=0) is False
+        assert is_in_active_window(r, _dt(11, 15), pre_season_days=0) is True
+
+    def test_tropical_always_in_season(self):
+        r = _resort(lat=20.0)
+        assert is_in_active_window(r, _dt(7, 1)) is True
+        assert is_in_active_window(r, _dt(1, 1)) is True
+        assert is_in_active_window(r, _dt(11, 15)) is True
+
+    def test_southern_hemisphere_default_end_oct_31(self):
+        """One week more forgiving than the plan (Oct 15 -> Oct 31)."""
+        r = _resort(lat=-32.8)
+        assert is_in_active_window(r, _dt(10, 31)) is True
+        assert is_in_active_window(r, _dt(11, 1)) is False
+
+    def test_southern_hemisphere_pre_season(self):
+        # Jun 1 - 21d = May 11 (non-leap) / May 11 (leap) since 21 days back.
+        # May 2026 is non-leap-relevant.
+        r = _resort(lat=-32.8)
+        assert is_in_active_window(r, _dt(5, 11)) is True
+        assert is_in_active_window(r, _dt(5, 10)) is False
+
+    def test_accepts_date_object(self):
+        """Function should accept a datetime (spec says datetime, but the
+        implementation tolerates a plain date too)."""
+        from datetime import date
+
+        r = _resort(lat=39.6)
+        # Pass datetime — primary API
+        assert is_in_active_window(r, datetime(2026, 3, 15, 9, 0)) is True
+
+    def test_resort_with_missing_latitude_defaults_northern(self):
+        r = _resort(lat=None)
+        # Missing lat -> defaults to Northern window
+        assert is_in_active_window(r, _dt(3, 1)) is True  # in-season for Northern
+        assert is_in_active_window(r, _dt(7, 1)) is False  # out for Northern
+
+    def test_pydantic_rejects_bad_month_day_format(self):
+        with pytest.raises(ValidationError):
+            _resort(
+                resort_id="bad",
+                lat=39.6,
+                season_start="Nov-15",
+                season_end="04-15",
+            )
+
+    def test_pydantic_rejects_impossible_date(self):
+        with pytest.raises(ValidationError):
+            _resort(
+                resort_id="bad",
+                lat=39.6,
+                season_start="13-15",
+                season_end="04-15",
+            )
+
+    def test_pydantic_rejects_day_out_of_range(self):
+        with pytest.raises(ValidationError):
+            _resort(
+                resort_id="bad",
+                lat=39.6,
+                season_start="02-30",
+                season_end="04-15",
+            )
+
+    def test_override_with_wrap_northern_style(self):
+        """Override that wraps across year end should behave like default."""
+        r = _resort(
+            resort_id="wrap",
+            lat=39.6,
+            season_start="12-01",
+            season_end="03-15",
+        )
+        assert is_in_active_window(r, _dt(1, 10)) is True
+        assert is_in_active_window(r, _dt(3, 16)) is False
+        # Pre-season buffer still applies: Dec 1 - 21d = Nov 10
+        assert is_in_active_window(r, _dt(11, 12)) is True
+        assert is_in_active_window(r, _dt(11, 9)) is False

--- a/backend/tests/test_static_json_generator.py
+++ b/backend/tests/test_static_json_generator.py
@@ -335,6 +335,61 @@ class TestStaticJsonGenerator:
         assert "data/snow-quality.json" in file_names
         assert result["success"] is True
 
+    def test_out_of_season_resort_short_circuits(
+        self, mock_dynamodb, mock_s3, sample_resort
+    ):
+        """Out-of-season resorts emit a stable "out_of_season" quality marker."""
+        generator = StaticJsonGenerator(
+            resorts_table_name="test-resorts",
+            weather_conditions_table_name="test-conditions",
+            website_bucket="test-bucket",
+        )
+
+        # Even if there are stale conditions, the out-of-season gate wins.
+        stale_condition = MagicMock()
+        stale_condition.elevation_level = "mid"
+        stale_condition.quality_score = 50
+        stale_condition.timestamp = "2024-05-01T00:00:00+00:00"
+        stale_condition.current_temp_celsius = 10.0
+        stale_condition.fresh_snow_cm = 0.0
+        stale_condition.snowfall_24h_cm = 0.0
+        stale_condition.snow_depth_cm = 0.0
+        stale_condition.predicted_snow_48h_cm = 0.0
+
+        with patch(
+            "services.static_json_generator.is_in_active_window", return_value=False
+        ):
+            result = generator._get_snow_quality_for_resort(
+                sample_resort, conditions=[stale_condition]
+            )
+
+        assert result["overall_quality"] == "out_of_season"
+        assert result["last_updated"] is None
+        assert result["temperature_c"] is None
+        assert result["snowfall_fresh_cm"] is None
+
+    def test_in_season_resort_with_no_conditions_returns_unknown(
+        self, mock_dynamodb, mock_s3, sample_resort
+    ):
+        """When in-season but no conditions, returns the "unknown" branch —
+        never the new "out_of_season" value (those are only for off-season).
+        """
+        generator = StaticJsonGenerator(
+            resorts_table_name="test-resorts",
+            weather_conditions_table_name="test-conditions",
+            website_bucket="test-bucket",
+        )
+
+        with patch(
+            "services.static_json_generator.is_in_active_window", return_value=True
+        ):
+            result = generator._get_snow_quality_for_resort(
+                sample_resort, conditions=[]
+            )
+
+        assert result["overall_quality"] == "unknown"
+        assert result["overall_quality"] != "out_of_season"
+
     def test_s3_upload_content_type_and_cache(self, mock_dynamodb, mock_s3):
         """Test that S3 uploads have correct content type and cache headers."""
         mock_table = MagicMock()

--- a/backend/tests/test_weather_processor.py
+++ b/backend/tests/test_weather_processor.py
@@ -1321,3 +1321,228 @@ class TestProcessorRawDataCollection:
 
             result = weather_processor_handler({}, _make_lambda_context())
             assert result["statusCode"] == 200
+
+
+# ---------------------------------------------------------------------------
+# Tests for season-aware polling gate
+# ---------------------------------------------------------------------------
+
+
+def _make_resort_with_season(
+    resort_id="test",
+    lat=49.72,
+    year_round=False,
+    season_start=None,
+    season_end=None,
+    region="na_west",
+):
+    """Build a Resort-like stub that season_utils can introspect."""
+    ep = SimpleNamespace(
+        level=SimpleNamespace(value="mid"),
+        latitude=lat,
+        longitude=-120.0,
+        elevation_meters=1800,
+    )
+    return SimpleNamespace(
+        resort_id=resort_id,
+        name=resort_id,
+        region=region,
+        elevation_points=[ep],
+        year_round=year_round,
+        season_start_month_day=season_start,
+        season_end_month_day=season_end,
+    )
+
+
+class TestSeasonFilterSequential:
+    """Out-of-season resorts are skipped entirely in sequential mode.
+
+    Rather than mock the system clock, we patch ``is_in_active_window`` so
+    the tests are time-independent and test the *wiring* rather than the
+    date math (the date math has dedicated coverage in test_season_utils.py).
+    """
+
+    MODULE = "handlers.weather_processor"
+
+    def test_out_of_season_resorts_are_skipped(self):
+        from handlers.weather_processor import weather_processor_handler
+
+        in_season = _make_resort_with_season(resort_id="in-season", lat=49.72)
+        off_season = _make_resort_with_season(resort_id="off-season", lat=39.6)
+
+        def fake_in_window(resort, now, pre_season_days=21):
+            return resort.resort_id == "in-season"
+
+        with (
+            patch(f"{self.MODULE}.PARALLEL_PROCESSING", False),
+            patch(f"{self.MODULE}.ENABLE_STATIC_JSON", False),
+            patch(f"{self.MODULE}.ENABLE_SCRAPING", False),
+            patch(f"{self.MODULE}.dynamodb"),
+            patch(f"{self.MODULE}.ResortService") as mock_rs_cls,
+            patch(f"{self.MODULE}.OpenMeteoService"),
+            patch(f"{self.MODULE}.SnowQualityService"),
+            patch(f"{self.MODULE}.SnowSummaryService"),
+            patch(f"{self.MODULE}.process_elevation_point") as mock_pep,
+            patch(f"{self.MODULE}.is_in_active_window", side_effect=fake_in_window),
+        ):
+            mock_rs_cls.return_value.get_all_resorts.return_value = [
+                in_season,
+                off_season,
+            ]
+            mock_pep.return_value = {
+                "success": True,
+                "error": None,
+                "level": "mid",
+                "weather_condition": SimpleNamespace(
+                    snow_quality=SimpleNamespace(value="good"),
+                    fresh_snow_cm=10.0,
+                    confidence_level=SimpleNamespace(value="high"),
+                ),
+            }
+
+            result = weather_processor_handler({}, _make_lambda_context(300000))
+
+        body = json.loads(result["body"])
+        assert result["statusCode"] == 200
+        assert body["stats"]["resorts_processed"] == 1
+        assert body["stats"]["resorts_skipped_off_season"] == 1
+        assert mock_pep.call_count == 1
+
+    def test_all_in_season_none_skipped(self):
+        from handlers.weather_processor import weather_processor_handler
+
+        r = _make_resort_with_season(resort_id="always-on", lat=49.72)
+
+        with (
+            patch(f"{self.MODULE}.PARALLEL_PROCESSING", False),
+            patch(f"{self.MODULE}.ENABLE_STATIC_JSON", False),
+            patch(f"{self.MODULE}.ENABLE_SCRAPING", False),
+            patch(f"{self.MODULE}.dynamodb"),
+            patch(f"{self.MODULE}.ResortService") as mock_rs_cls,
+            patch(f"{self.MODULE}.OpenMeteoService"),
+            patch(f"{self.MODULE}.SnowQualityService"),
+            patch(f"{self.MODULE}.SnowSummaryService"),
+            patch(f"{self.MODULE}.process_elevation_point") as mock_pep,
+            patch(f"{self.MODULE}.is_in_active_window", return_value=True),
+        ):
+            mock_rs_cls.return_value.get_all_resorts.return_value = [r]
+            mock_pep.return_value = {
+                "success": True,
+                "error": None,
+                "level": "mid",
+                "weather_condition": SimpleNamespace(
+                    snow_quality=SimpleNamespace(value="good"),
+                    fresh_snow_cm=10.0,
+                    confidence_level=SimpleNamespace(value="high"),
+                ),
+            }
+
+            result = weather_processor_handler({}, _make_lambda_context(300000))
+
+        body = json.loads(result["body"])
+        assert body["stats"]["resorts_processed"] == 1
+        assert body["stats"]["resorts_skipped_off_season"] == 0
+
+    def test_uses_21_day_pre_season_buffer(self):
+        """Polling uses a 21-day pre-season buffer (not the default of 21)."""
+        from handlers.weather_processor import weather_processor_handler
+
+        r = _make_resort_with_season(resort_id="whistler", lat=49.72)
+        seen_buffers: list[int] = []
+
+        def fake_in_window(resort, now, pre_season_days=21):
+            seen_buffers.append(pre_season_days)
+            return True
+
+        with (
+            patch(f"{self.MODULE}.PARALLEL_PROCESSING", False),
+            patch(f"{self.MODULE}.ENABLE_STATIC_JSON", False),
+            patch(f"{self.MODULE}.ENABLE_SCRAPING", False),
+            patch(f"{self.MODULE}.dynamodb"),
+            patch(f"{self.MODULE}.ResortService") as mock_rs_cls,
+            patch(f"{self.MODULE}.OpenMeteoService"),
+            patch(f"{self.MODULE}.SnowQualityService"),
+            patch(f"{self.MODULE}.SnowSummaryService"),
+            patch(f"{self.MODULE}.process_elevation_point") as mock_pep,
+            patch(f"{self.MODULE}.is_in_active_window", side_effect=fake_in_window),
+        ):
+            mock_rs_cls.return_value.get_all_resorts.return_value = [r]
+            mock_pep.return_value = {
+                "success": True,
+                "error": None,
+                "level": "mid",
+                "weather_condition": SimpleNamespace(
+                    snow_quality=SimpleNamespace(value="good"),
+                    fresh_snow_cm=10.0,
+                    confidence_level=SimpleNamespace(value="high"),
+                ),
+            }
+
+            weather_processor_handler({}, _make_lambda_context(300000))
+
+        assert seen_buffers and all(b == 21 for b in seen_buffers)
+
+
+class TestSeasonFilterParallel:
+    """Out-of-season resorts are skipped in orchestrate_parallel_processing too."""
+
+    MODULE = "handlers.weather_processor"
+
+    def test_off_season_resorts_not_dispatched(self):
+        from handlers.weather_processor import orchestrate_parallel_processing
+
+        in_season = _make_resort_with_season(
+            resort_id="portillo", lat=-32.8, region="south_america"
+        )
+        off_season = _make_resort_with_season(
+            resort_id="vail", lat=39.6, region="na_rockies"
+        )
+
+        def fake_in_window(resort, now, pre_season_days=21):
+            return resort.resort_id == "portillo"
+
+        with (
+            patch(f"{self.MODULE}.dynamodb"),
+            patch(f"{self.MODULE}.ResortService") as mock_rs_cls,
+            patch(f"{self.MODULE}.lambda_client") as mock_lc,
+            patch(f"{self.MODULE}.is_in_active_window", side_effect=fake_in_window),
+        ):
+            mock_rs_cls.return_value.get_all_resorts.return_value = [
+                in_season,
+                off_season,
+            ]
+            mock_lc.invoke.return_value = {"StatusCode": 202}
+
+            result = orchestrate_parallel_processing(_make_lambda_context())
+
+        body = json.loads(result["body"])
+        assert body["total_resorts"] == 1  # Only in-season dispatched
+        assert body["skipped_off_season"] == 1
+        assert body["workers_invoked"] == 1
+        # The payload sent to the worker should only contain the in-season resort.
+        payload = json.loads(mock_lc.invoke.call_args[1]["Payload"])
+        assert payload["resort_ids"] == ["portillo"]
+
+    def test_all_resorts_off_season_returns_early(self):
+        from handlers.weather_processor import orchestrate_parallel_processing
+
+        off_season = _make_resort_with_season(
+            resort_id="vail", lat=39.6, region="na_rockies"
+        )
+
+        with (
+            patch(f"{self.MODULE}.dynamodb"),
+            patch(f"{self.MODULE}.ResortService") as mock_rs_cls,
+            patch(f"{self.MODULE}.lambda_client") as mock_lc,
+            patch(f"{self.MODULE}.is_in_active_window", return_value=False),
+        ):
+            mock_rs_cls.return_value.get_all_resorts.return_value = [off_season]
+
+            result = orchestrate_parallel_processing(_make_lambda_context())
+
+        body = json.loads(result["body"])
+        assert result["statusCode"] == 200
+        assert body["skipped_off_season"] == 1
+        assert body["total_resorts"] == 1
+        # No lambda invocations.
+        mock_lc.invoke.assert_not_called()


### PR DESCRIPTION
## Summary

Stops polling and alerting on resorts outside their active ski season window. Addresses the user's complaint about receiving snow/icy alerts in late April for already-closed resorts.

## Design

- **New**: \`backend/src/utils/season_utils.py\` — pure module with hemisphere detection, season windows, per-resort overrides, and \`is_in_active_window(resort, now, pre_season_days)\`.
- **Defaults**: Northern Nov 15 → May 10, Southern Jun 1 → Oct 31.
- **Year-round**: \`|lat| < 25\` (indoor/equatorial), or explicit \`year_round=True\` on the resort.
- **Per-resort override**: optional \`season_start_month_day\` / \`season_end_month_day\` (both \`MM-DD\`; both required together).
- **Pre-season buffer**: 21 days, to warm caches 3 weeks before each season opens.

## Gates

- **Polling** (\`weather_processor.py\`, both parallel and sequential paths): filters resorts with \`pre_season_days=21\`. Out-of-season resorts skip Open-Meteo calls, scraper fetches, and DynamoDB writes entirely. Logs \`skipped_off_season\` counter in stats.
- **Alerts** (\`notification_service.py\`): blocks \`FRESH_SNOW\`, \`POWDER\`, \`THAW_FREEZE\`, \`FORECAST\` with \`pre_season_days=0\`. \`RESORT_EVENT\` remains unconditional (opening-date announcements are useful off-season). Fail-open if resort can't be loaded.
- **Static JSON** (\`static_json_generator.py\`): out-of-season resorts return \`overall_quality: "out_of_season"\`, \`last_updated: null\`. Shape mirrors the \`unknown\` fallback.

## Client safety (no breakage)

All three clients decode unknown \`SnowQuality\` values into \`UNKNOWN\` gracefully:
- iOS: \`WeatherCondition.swift:90\` → \`self = .unknown\`
- Android: \`Models.kt:408\` → \`?: SnowQuality.UNKNOWN\`
- Web: \`ComparePage.tsx:247\` → \`?? 'Unknown'\`

So shipping the backend alone will not crash clients. Users of out-of-season resorts will see "Unknown" until client enums are updated in a follow-up PR.

## Tests
- \`1750 → 1802 passing\` (+52).
- Covers: hemisphere detection, year wrap, tropical edge cases, override semantics, polling skip (parallel + sequential), alert gating per type (including RESORT_EVENT exemption), static JSON short-circuit.

## Known follow-ups (not in this PR)

1. **iOS / Android / Web**: add \`outOfSeason = "out_of_season"\` enum case + "Season ended" badge (currently falls through to "Unknown").
2. **Per-resort overrides**: consider setting \`season_end_month_day="04-15"\` on early-closing resorts (Vail, Breckenridge, Park City) so their alerts stop sooner than the May 10 default. Do the opposite for late-closing resorts (Whistler, Mammoth, Timberline, A-Basin).
3. Code review flagged P2 items worth addressing in follow-ups: one redundant DB lookup in notification loop, metrics on missing-lat fallback, tropical boundary test at exactly \`|lat|=25.0\`.

## Test plan
- [ ] Backend tests: \`PYTHONPATH=src pytest backend/tests -x -q\` → all 1802 passing
- [ ] Deploy to staging; wait 1 hour; check CloudWatch logs for \`skipped_off_season\` counter. Expect ~50-70% skipped for Northern resorts in late April.
- [ ] Inspect static JSON in S3: \`aws s3 cp s3://snow-tracker-.../data/snow-quality.json - | jq '[.results[] | select(.overall_quality == "out_of_season")] | length'\` should show roughly that same ratio.
- [ ] Confirm no push notifications fire for closed resorts (subscribe a test device to a closed resort's region; wait for next cron).