### PR TITLE
Standardize header badges (App Store / Website / Issues)

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,9 @@
 </p>
 
 <p align="center">
-  <a href="https://powderchaserapp.com">Website</a> &bull;
-  <a href="https://apps.apple.com/app/powder-chaser">App Store</a> &bull;
-  <a href="https://buymeacoffee.com/wdvr">Buy Me a Coffee</a>
+  <a href="https://apps.apple.com/app/powder-chaser/id6758333173"><img alt="App Store" src="https://img.shields.io/badge/App_Store-Download-007AFF?style=flat-square&logo=apple&logoColor=white" /></a>
+  <a href="https://powderchaserapp.com"><img alt="Website" src="https://img.shields.io/badge/Website-powderchaserapp.com-2E7D32?style=flat-square" /></a>
+  <a href="https://github.com/wdvr/snow/issues"><img alt="Issues" src="https://img.shields.io/github/issues/wdvr/snow?style=flat-square" /></a>
 </p>
 
 ---


### PR DESCRIPTION
## Summary

The README opens with a plain-text link row (Website · App Store · Buy Me a Coffee). Replacing it with the same shields.io badge set used on wdvr/footprint and BalloonInc/trivit so the three apps have a consistent look on github.com:

1. **App Store** — `https://apps.apple.com/app/powder-chaser/id6758333173`
2. **Website** — powderchaserapp.com
3. **Issues** — dynamic count from this repo

Dropped the "Buy Me a Coffee" link from the badge row to keep the three apps consistent; happy to re-add it as a 4th badge or move it elsewhere in the README if you want it preserved.

If the App Store ID is wrong, ping me and I'll fix it.

## Test plan

- [ ] Badge row renders on github.com/wdvr/snow
- [ ] App Store badge opens https://apps.apple.com/app/powder-chaser/id6758333173
- [ ] Website + Issues badges work